### PR TITLE
feat: [M4] harness-loop skill (T-030〜T-039, closes #37)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -24,6 +24,7 @@
 | [skill-suggest](skills/skill-suggest/) | プロジェクトの技術スタックを自動解析し、skills.shレジストリから最適なスキルを提案・インストール |
 | [harness-init](skills/harness-init/) | Harness 制御ループ（Planner/Generator/Evaluator サブエージェント・hooks・ガードスクリプト・耐性ファイル）をプロジェクトに導入 |
 | [harness-plan](skills/harness-plan/) | /harness の epic を計画: 対話で product-spec.md を起草、bundling 判定付き roadmap.md を導出、sprint 毎に tracker Issue を起票 |
+| [harness-loop](skills/harness-loop/) | GAN 制御ループを実行: sprint 毎に contract を交渉し、Generator ⇄ Evaluator を rubric 収束まで反復、PR を作成。interactive / continuous / autonomous-ralph / scheduled 4 モードと Principal Skinner 停止ガード対応 |
 
 ## インストール
 
@@ -48,6 +49,7 @@ npx skills add anyoneanderson/agent-skills --skill cmux-second-opinion -g -y
 npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 npx skills add anyoneanderson/agent-skills --skill harness-init -g -y
 npx skills add anyoneanderson/agent-skills --skill harness-plan -g -y
+npx skills add anyoneanderson/agent-skills --skill harness-loop -g -y
 ```
 
 > **Note**: cmux スキルは [cmux](https://cmux.dev/)（macOS 14.0+）が必要で、cmux セッション内で実行する必要があります。

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Reusable AI agent skills for specification-driven development.
 | [skill-suggest](skills/skill-suggest/) | Auto-detect project tech stack and suggest optimal skills from skills.sh registry |
 | [harness-init](skills/harness-init/) | Install the Harness control loop (Planner/Generator/Evaluator sub-agents, hooks, guard scripts, resilience files) into a project |
 | [harness-plan](skills/harness-plan/) | Plan an epic for /harness: draft product-spec.md interactively, derive roadmap.md with bundling judgement, emit one tracker Issue per sprint |
+| [harness-loop](skills/harness-loop/) | Run the GAN control loop: per sprint, negotiate the contract, iterate Generator ⇄ Evaluator to rubric convergence, open the PR. Supports interactive / continuous / autonomous-ralph / scheduled modes with Principal Skinner stop guards |
 
 ## Installation
 
@@ -48,6 +49,7 @@ npx skills add anyoneanderson/agent-skills --skill cmux-second-opinion -g -y
 npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 npx skills add anyoneanderson/agent-skills --skill harness-init -g -y
 npx skills add anyoneanderson/agent-skills --skill harness-plan -g -y
+npx skills add anyoneanderson/agent-skills --skill harness-loop -g -y
 ```
 
 > **Note**: cmux skills require [cmux](https://cmux.dev/) (macOS 14.0+) and must be run inside a cmux session.

--- a/skills/harness-loop/SKILL.md
+++ b/skills/harness-loop/SKILL.md
@@ -210,8 +210,11 @@ Write contract final frontmatter: populated `acceptance_scenarios`,
 
 ### Step 5: Contract Freeze and Commit
 
-1. `git add .harness/<epic>/sprints/sprint-<n>-*/contract.md
-   .harness/<epic>/sprints/sprint-<n>-*/shared_state.md`
+1. `git add .harness/<epic>/sprints/sprint-<n>-*/` — captures
+   `contract.md`, `shared_state.md`, the negotiation-round feedback
+   files (`feedback/generator-<r>.md`, `feedback/evaluator-<r>.md`,
+   `feedback/planner-ruling.md` if present) and any evidence from
+   negotiation. The whole audit trail lands in one commit
 2. `git commit -m "harness-loop: sprint-<n> contract frozen"`
 3. Store the SHA in `_state.json.last_commit`
 4. Append `progress.md`: `decision: sprint-<n> contract frozen @ <SHA>`

--- a/skills/harness-loop/SKILL.md
+++ b/skills/harness-loop/SKILL.md
@@ -1,0 +1,434 @@
+---
+name: harness-loop
+description: |
+  Run the GAN control loop for one epic: for each sprint, negotiate the
+  contract, iterate Generator ⇄ Evaluator to rubric convergence (or
+  Principal Skinner stop), checkpoint to progress.md + _state.json +
+  git + metrics.jsonl every iteration, and open the PR. Handles
+  interactive / continuous / autonomous-ralph / scheduled execution modes.
+
+  Prerequisite: /harness-init and /harness-plan must have completed.
+  _state.json.phase must be "ready-for-loop" (fresh) or one of the
+  in-sprint phases (resume).
+
+  English triggers: "Run harness-loop", "Start the sprint loop", "Execute sprints"
+  日本語トリガー: 「harness-loop を実行」「sprint ループを開始」「自律実装を開始」
+license: MIT
+---
+
+# harness-loop — Autonomous Sprint Execution Loop
+
+Consumes the sprint backlog produced by `harness-plan` and runs each
+sprint through a Negotiation → Implementation → PR pipeline until the
+epic completes or Principal Skinner stops the loop. Designed to survive
+context compaction, session restarts, and overnight runs: every state
+transition lands in `.harness/progress.md`, `.harness/_state.json`,
+`.harness/metrics.jsonl`, and git.
+
+Roles coordinating through this orchestrator:
+
+- **Planner** (Claude) — arbiter of negotiation stalemates and replans
+- **Generator** (Claude / Codex via cmux / other) — writes code
+- **Evaluator** (Claude + Playwright/pytest/curl) — scores rubric
+
+This skill is the orchestrator, not an agent. It reads and writes the
+shared ledger, dispatches sub-agents, and advances the cursor. It never
+writes implementation code or rubric verdicts itself.
+
+## Language Rules
+
+1. Auto-detect input language → respond in the same language
+2. Japanese input → Japanese output
+3. English input → English output
+4. Explicit override (e.g., "in English", "日本語で") takes priority
+5. All `AskUserQuestion` options are bilingual (`"English / 日本語"`)
+
+Reference files exist as `<name>.md` (English) and `<name>.ja.md`
+(Japanese). Pick the pair matching the detected language.
+
+## Prerequisites
+
+Verify before any sprint work:
+
+1. **Harness initialised** — `.harness/_config.yml`,
+   `.harness/scripts/progress-append.sh`, and
+   `.claude/agents/{planner,generator,evaluator}.md` exist. If not, stop
+   and instruct the user to run `/harness-init`.
+2. **Plan completed** — `.harness/<epic>/roadmap.md` exists and
+   `_state.json.phase ∈ {ready-for-loop, negotiation, impl, evaluation,
+   pr, done}`. If `phase == product-spec-draft | roadmap-draft |
+   roadmap-approved | issues-pending`, stop and instruct the user to
+   finish `/harness-plan` first.
+3. **`jq` and `git`** available — `command -v jq` and
+   `git rev-parse --is-inside-work-tree`. Required for all state IO.
+4. **Tracker pre-flight** — if `_config.yml.tracker == github`, run
+   `gh auth status`. Fail fast rather than mid-PR.
+
+Do not partially execute on failure. Surface the missing piece and exit.
+
+## Boot Sequence (REQ-072)
+
+Execute first on every invocation — fresh session or resume:
+
+1. `git log --oneline -20`
+2. `tail -100 .harness/progress.md` (if present)
+3. `cat .harness/_state.json`
+
+Decision table after Boot:
+
+| `_state.json` condition | Action |
+|---|---|
+| `completed == true` | Report "epic done" and exit. Suggest next epic via `/harness-plan` |
+| `aborted_reason != null` | Surface reason; ask user to resolve before resume (interactive only) |
+| `pending_human == true` | Tier-A halt; surface details and stop (see Step 7) |
+| `phase == ready-for-loop` | Fresh start — enter Step 2 |
+| `phase ∈ {negotiation, impl, evaluation, pr}` | Resume — enter Step 2 and branch by phase |
+
+In `interactive` mode the skill confirms resume vs restart via
+`AskUserQuestion`. In non-interactive modes it auto-resumes per
+`_state.json` (ASM-007).
+
+## Execution Flow (10 steps)
+
+### Step 1: Detect State and Mode Context
+
+Parse `_state.json`. If `.mode` is already set (resume path), honour it.
+Otherwise Step 2 elicits the mode. Compute:
+
+- `current_epic`, `current_sprint`, `phase`, `iteration`
+- Remaining Principal Skinner budget (see Step 7)
+- Active sprint directory: `.harness/<epic>/sprints/sprint-<n>-<feature>/`
+
+### Step 2: Execution Mode Selection (T-037)
+
+Mode is chosen once at loop start and persisted to `_state.json.mode`.
+**Interactive mode is the only mode permitted to call
+`AskUserQuestion`** during the loop (ASM-007, REQ-078). All other
+modes read any branching value from `_config.yml`.
+
+```
+if _state.json.mode is null:
+  if interactive session (TTY + not -p):
+    AskUserQuestion:
+      question: "Execution mode?" / "実行モード?"
+      options:
+        - "interactive — confirm each iteration / 各 iteration で確認"
+        - "continuous — run to completion in this session / 完走まで続行 (Recommended)"
+        - "autonomous-ralph — fresh context per iter / 毎 iter 独立 context"
+        - "scheduled — Ralph every N iters / N iter 毎に Ralph"
+  else:
+    mode = _config.yml.default_mode | "continuous"
+  persist to _state.json.mode
+```
+
+| Mode | Loop control | AskUserQuestion | Reference |
+|---|---|---|---|
+| `interactive` | Skill in-process; pause after each iter | allowed | — |
+| `continuous` | Skill in-process; run to completion | **forbidden** | — |
+| `autonomous-ralph` | External shell wrapper; `claude -p --bare` per iter | **forbidden** | [autonomous-ralph.md](references/autonomous-ralph.md) |
+| `scheduled` | Mix of continuous + Ralph at fixed cadence | **forbidden** | [autonomous-ralph.md](references/autonomous-ralph.md) |
+
+For `autonomous-ralph` and `scheduled`, this skill exits after one
+iteration; the shell wrapper re-invokes it for the next.
+
+### Step 3: Load Current Sprint
+
+Read `.harness/<epic>/roadmap.md` frontmatter; select the sprint where
+`n == _state.json.current_sprint`. Load:
+
+- `.../contract.md` — contract with empty `acceptance_scenarios` /
+  `rubric` on fresh entry, populated on resume
+- `.../shared_state.md` — sprint ledger (Orchestrator-only writes)
+- `.../feedback/` — per-role per-iter files (agents write here)
+
+If the sprint directory is missing (roadmap drift), emit
+`aborted_reason: "sprint-missing:<n>"` and halt.
+
+Set `_state.json.phase = "negotiation"` if fresh, else keep as read.
+
+### Step 4: Negotiation Phase (T-031)
+
+Governed by [negotiation-protocol.md](references/negotiation-protocol.md).
+
+```
+if contract.status == "active":
+  skip Step 4 (already negotiated, resume case)
+
+for round in 1..contract.max_negotiation_rounds (default 3):
+  dispatch Generator sub-agent with contract draft + shared_state.md
+  Generator appends to feedback/generator-<round>.md
+  Orchestrator copies round summary to shared_state.md/Negotiation
+
+  dispatch Evaluator sub-agent symmetrically
+  Evaluator appends to feedback/evaluator-<round>.md
+  Orchestrator copies round summary to shared_state.md/Negotiation
+
+  if both agree:
+    break
+
+if no agreement after max rounds:
+  dispatch Planner; Planner writes feedback/planner-ruling.md
+  Orchestrator copies ruling to contract Negotiation Log
+```
+
+Append one `progress.md` line per round:
+
+```
+[<ts>] negotiation: round=<r> agent=<role> summary=<short>
+```
+
+Write contract final frontmatter: populated `acceptance_scenarios`,
+`rubric` (from `rubric-presets.md`), `max_iterations`. Flip
+`status: active` and record the contract commit SHA in
+`shared_state.md/Contract`. Advance `_state.json.phase = "impl"`.
+
+### Step 5: Contract Freeze and Commit
+
+1. `git add .harness/<epic>/sprints/sprint-<n>-*/contract.md
+   .harness/<epic>/sprints/sprint-<n>-*/shared_state.md`
+2. `git commit -m "harness-loop: sprint-<n> contract frozen"`
+3. Store the SHA in `_state.json.last_commit`
+4. Append `progress.md`: `decision: sprint-<n> contract frozen @ <SHA>`
+
+### Step 6: Implementation Loop (T-032, T-033)
+
+Governed by [shared-state-protocol.md](references/shared-state-protocol.md).
+
+```
+while iteration < contract.max_iterations:
+  iteration += 1
+  start_ts = now()
+
+  # Generator turn
+  dispatch Generator with:
+    - contract.md (frozen)
+    - shared_state.md (read-only)
+    - previous iteration's feedback/evaluator-<iter-1>.md (if fail)
+  Generator edits source files; appends to feedback/generator-<iter>.md
+
+  # Evaluator turn
+  dispatch Evaluator with:
+    - contract.md
+    - shared_state.md
+    - the new source state
+  Evaluator runs rubric checks; appends to feedback/evaluator-<iter>.md
+  Orchestrator copies verdict to shared_state.md/WorkLog and /Evaluation
+
+  # Per-iteration checkpoint (Step 7)
+  checkpoint(iteration, start_ts)
+
+  if all axes >= threshold:
+    contract.status = "done"
+    break
+
+  # Principal Skinner check (Step 7)
+  if any stop-condition fires:
+    contract.status = "aborted"
+    set _state.json.aborted_reason
+    break
+```
+
+Evaluator failure format (input to the next Generator call):
+
+```yaml
+iter: <n>
+verdict: fail
+failing_axes:
+  - axis: Functionality
+    score: 0.6
+    threshold: 1.0
+    notes: "AS-2 fails: login redirect 500s"
+    evidence: sprints/sprint-<n>-*/evidence/AS-2-run-<iter>.trace
+retry_hint: "Tighten session lookup; see evidence trace line 42"
+```
+
+Each iteration ends with a commit (see Step 7) so every attempt is
+reviewable in git history.
+
+### Step 7: Iteration Checkpoint and Principal Skinner (T-036, T-038)
+
+At the end of every iteration (pass OR fail OR abort), atomically:
+
+1. **Update `_state.json`** via `jq` into a tmp file, then rename:
+   - `iteration`, `last_agent`, `next_action`, `last_commit`
+   - `features_pass_fail` (per-axis for this sprint's features)
+   - `cumulative_cost_usd += cost_this_iter`
+   - `rubric_stagnation_count` — increment if no axis improved this iter; reset to 0 on any improvement
+
+2. **Append one line to `.harness/metrics.jsonl`**:
+   ```json
+   {"ts":"<ISO>","iter":<n>,"sprint":<s>,"agent":"<role>","duration_ms":<d>,"input_tokens":<i>,"output_tokens":<o>,"cost_usd":<c>,"rubric_scores":{...},"tool_calls":<t>,"tool_failures":<f>}
+   ```
+
+3. **Commit**: `git add -A && git commit -m "harness-loop: sprint-<n> iter-<iter>"` (non-fatal on `git commit` failure; log to progress.md and continue).
+
+4. **Principal Skinner stop-check** — evaluate all five conditions; on any hit set `_state.json.aborted_reason` and stop:
+
+   | Condition | Computed from | Default |
+   |---|---|---|
+   | `iteration >= max_iterations` | contract + state | 8 |
+   | `wall_time >= max_wall_time_sec` | `now - start_time` | 28800 (8h) |
+   | `rubric_stagnation_count >= rubric_stagnation_n` | state + `_config.yml.rubric_stagnation_n` | 3 |
+   | `cumulative_cost_usd >= max_cost_usd` | state + `_config.yml.max_cost_usd` | 20.0 |
+   | `pending_human == true` | set by `.harness/scripts/tier-a-guard.sh` PreToolUse hook | — |
+
+5. Append a `progress.md` line:
+   ```
+   [<ts>] evaluation: iter=<n> verdict=<pass|fail> axes="f=.. c=.. d=.. o=.."
+   ```
+   And on abort:
+   ```
+   [<ts>] stop: reason=<max_iter|wall_time|rubric_stagnation|cost_cap|tier_a> detail=<text>
+   ```
+
+Principal Skinner never deletes state. The loop stops and leaves
+everything on disk for a later resume (pending_human), a replan
+(rubric_stagnation), or a manual budget bump (cost_cap, wall_time).
+
+### Step 8: PR Creation on Sprint Pass (T-034)
+
+Governed by [pr-creation-guide.md](references/pr-creation-guide.md).
+
+When `contract.status == "done"`:
+
+1. Ensure all iteration commits are on a feature branch named
+   `harness/<epic>/sprint-<n>-<feature>` (the wrapper creates this; if
+   running in-process, `git switch -c` it before Step 4 if not present).
+2. `git push -u origin <branch>` (skip when `tracker == none`).
+3. For `bundling: split` — one PR per sprint. For `bundling: bundled` —
+   open a single PR whose body lists all bundled features (the roadmap
+   entry already references `bundled_with`).
+4. PR body is built from the template in `pr-creation-guide.md`, quoting
+   the `shared_state.md/Evaluation` block and linking the sprint Issue
+   (`_state.json.sprint_issues[<n>]`).
+5. Record PR URL to `_state.json.sprint_issues[<n>].pr` and append
+   `progress.md`:
+   ```
+   [<ts>] decision: sprint-<n> PR opened <url>
+   ```
+
+On `contract.status == "aborted"` skip PR creation. Record the abort in
+`shared_state.md/Decisions` and keep the branch intact so the user can
+inspect or resume.
+
+### Step 9: Sprint Transition (T-035)
+
+After Step 8 completes (pass) or on abort:
+
+```
+if _state.json.aborted_reason != null:
+  stop the loop; surface to the user; do not advance current_sprint
+
+else if any sprint remains in roadmap:
+  _state.json.current_sprint += 1
+  _state.json.iteration = 0
+  _state.json.phase = "negotiation"
+  _state.json.start_time = now()
+  _state.json.rubric_stagnation_count = 0
+  features_pass_fail = []     # reset per-sprint
+  if mode == interactive:
+    AskUserQuestion: "Proceed to sprint <n+1>?" — yes | pause | abort
+  go to Step 3
+
+else:
+  _state.json.completed = true
+  _state.json.phase = "done"
+  go to Step 10
+```
+
+`cumulative_cost_usd` and `start_time`'s wall-time budget reset is a
+policy choice. v1 keeps `cumulative_cost_usd` accumulating across the
+whole epic (so the cost cap is epic-wide). `start_time` resets per
+sprint so the 8h wall-time cap applies per sprint. Document both in
+`progress.md` on reset.
+
+### Step 10: Final Summary
+
+On `completed == true`:
+
+- Emit a report to the user:
+  - Epic name + total sprints run
+  - PR URLs per sprint (or "bundled" groups)
+  - Total cost (`cumulative_cost_usd`), total wall-time, total iterations
+  - Any sprints aborted (with reason)
+- Append `progress.md`:
+  ```
+  [<ts>] decision: epic=<name> completed sprints=<N> cost=<$> iters=<total>
+  ```
+- Do not touch `_state.json.completed` again. Leave for audit.
+
+Suggest `/harness-rules-update` if any sprint aborted or if
+`rubric_stagnation` fired — those are exactly the failure shapes that
+skill refines.
+
+## Error Handling
+
+| Situation | Response |
+|---|---|
+| `.harness/_config.yml` missing | Error: "Run `/harness-init` first." |
+| `.harness/<epic>/roadmap.md` missing | Error: "Run `/harness-plan` first." |
+| `jq` not found | Error: "Install `jq` — hooks and state IO require it." |
+| `gh` missing when tracker=github | Abort before sprint work; do not silently swap trackers |
+| Generator sub-agent fails to launch | Log to `feedback/generator-<iter>.md`; retry once; on second fail set `pending_human=true` |
+| Evaluator cannot run test tool | Record verdict `fail` with `reason: tool-unavailable`; Principal Skinner rubric-stagnation path handles eventual halt |
+| `git commit` fails mid-iter (e.g., hook rejection) | Log line; continue; do not bypass hooks |
+| Negotiation rounds exceeded without Planner ruling file | Planner absent or failed; set `pending_human=true` and halt |
+| `_state.json` unparseable (corruption) | Halt immediately; never overwrite. User reconstructs from git history |
+| AskUserQuestion attempted in non-interactive mode | Bug — fix call site. Fall back to `_config.yml` default with a progress line warning |
+
+## Usage
+
+```
+# Start from a planned epic
+/harness-loop
+
+# Resume after compact / restart / abort (auto-detected from _state.json)
+/harness-loop
+
+# Force a specific mode (overrides stored mode; recorded to _state.json)
+/harness-loop --mode continuous
+/harness-loop --mode autonomous-ralph
+/harness-loop --mode scheduled --ralph-every 5
+
+# Force a specific sprint (skip remaining earlier sprints; requires confirmation)
+/harness-loop --from-sprint 3
+
+# Replan aborted sprint (re-enter Negotiation, reset iteration to 0)
+/harness-loop --replan-current-sprint
+```
+
+`--mode autonomous-ralph` exits after one iteration; pair it with the
+shell wrapper in [autonomous-ralph.md](references/autonomous-ralph.md).
+
+## What harness-loop does NOT do
+
+- Does not change the epic plan (roadmap.md) — use `/harness-plan --replan`
+- Does not edit rubric after contract freeze — re-enter Negotiation via `--replan-current-sprint`
+- Does not refine rules from failures — `/harness-rules-update` does that
+- Does not configure hooks or agents — `/harness-init` owns those files
+- Does not bypass `.harness/scripts/tier-a-guard.sh` denials — human approval is required
+
+## Observability
+
+Every run lands in four files:
+
+- `.harness/progress.md` — human trace (append-only)
+- `.harness/_state.json` — machine cursor (atomic writes)
+- `.harness/metrics.jsonl` — per-iter metrics (append-only)
+- `git log` — one commit per iteration
+
+Optional OTLP export when `_config.yml.hook_level == strict` and
+`otlp_endpoint` is set — see [otlp-exporter.md](references/otlp-exporter.md).
+
+## References
+
+- [negotiation-protocol.md](references/negotiation-protocol.md) — round-by-round format, stalemate handling, Planner ruling schema
+- [shared-state-protocol.md](references/shared-state-protocol.md) — Shared-read / Isolated-write discipline across agents
+- [pr-creation-guide.md](references/pr-creation-guide.md) — split vs bundled PR body templates and `gh pr create` invocation
+- [autonomous-ralph.md](references/autonomous-ralph.md) — shell wrapper for `claude -p --bare` per-iteration execution
+- [otlp-exporter.md](references/otlp-exporter.md) — optional metrics pipeline
+- [../harness-init/references/resilience-schema.md](../harness-init/references/resilience-schema.md) — `_state.json` and `metrics.jsonl` canonical schema
+- [../harness-init/references/rubric-presets.md](../harness-init/references/rubric-presets.md) — axis sets by project type
+
+See `.specs/harness-suite/` in the source repo for requirement.md,
+design.md, and tasks.md governing this skill.

--- a/skills/harness-loop/SKILL.md
+++ b/skills/harness-loop/SKILL.md
@@ -90,7 +90,7 @@ In `interactive` mode the skill confirms resume vs restart via
 
 ## Execution Flow (10 steps)
 
-### Step 1: Detect State and Mode Context
+### Step 1: Detect State, Pin Generator Backend, Compute Context
 
 Parse `_state.json`. If `.mode` is already set (resume path), honour it.
 Otherwise Step 2 elicits the mode. Compute:
@@ -98,6 +98,25 @@ Otherwise Step 2 elicits the mode. Compute:
 - `current_epic`, `current_sprint`, `phase`, `iteration`
 - Remaining Principal Skinner budget (see Step 7)
 - Active sprint directory: `.harness/<epic>/sprints/sprint-<n>-<feature>/`
+
+**Pin the Generator backend once per loop run (REQ-060)**:
+
+```
+backend = _config.yml.generator_backend    # claude | codex_cmux | codex_plugin | other
+
+if backend == "codex_cmux" and command -v cmux fails:
+  backend = "claude"
+  append progress.md:
+    [<ts>] decision: generator_backend codex_cmux unavailable (cmux missing)
+           — fell back to claude for this run
+```
+
+Persist the effective backend to
+`_state.json.effective_generator_backend` for the rest of the run.
+Every `dispatch Generator` call in Step 6 uses this pinned value; it
+does not re-evaluate mid-loop. On resume in a later session the pin is
+re-derived from current `_config.yml` + env, not inherited, so a
+newly-installed cmux is picked up automatically.
 
 ### Step 2: Execution Mode Selection (T-037)
 
@@ -108,7 +127,9 @@ modes read any branching value from `_config.yml`.
 
 ```
 if _state.json.mode is null:
-  if interactive session (TTY + not -p):
+  if mode passed via --mode <value> flag:
+    mode = <value>    # user-explicit; no prompt
+  else if interactive session (TTY + not -p):
     AskUserQuestion:
       question: "Execution mode?" / "実行モード?"
       options:
@@ -117,9 +138,14 @@ if _state.json.mode is null:
         - "autonomous-ralph — fresh context per iter / 毎 iter 独立 context"
         - "scheduled — Ralph every N iters / N iter 毎に Ralph"
   else:
-    mode = _config.yml.default_mode | "continuous"
+    mode = "continuous"    # safe default for non-interactive with no flag
   persist to _state.json.mode
 ```
+
+Mode override precedence: `--mode` CLI flag > existing `_state.json.mode`
+> interactive prompt > `"continuous"` default. harness-loop does not
+read a `default_mode` from `_config.yml` in v1 (harness-init does not
+hear that value).
 
 | Mode | Loop control | AskUserQuestion | Reference |
 |---|---|---|---|
@@ -200,6 +226,7 @@ while iteration < contract.max_iterations:
   start_ts = now()
 
   # Generator turn
+  _state.json.phase = "impl"
   dispatch Generator with:
     - contract.md (frozen)
     - shared_state.md (read-only)
@@ -207,6 +234,7 @@ while iteration < contract.max_iterations:
   Generator edits source files; appends to feedback/generator-<iter>.md
 
   # Evaluator turn
+  _state.json.phase = "evaluation"
   dispatch Evaluator with:
     - contract.md
     - shared_state.md
@@ -214,55 +242,65 @@ while iteration < contract.max_iterations:
   Evaluator runs rubric checks; appends to feedback/evaluator-<iter>.md
   Orchestrator copies verdict to shared_state.md/WorkLog and /Evaluation
 
-  # Per-iteration checkpoint (Step 7)
-  checkpoint(iteration, start_ts)
-
-  if all axes >= threshold:
+  # Decide verdict and terminal state BEFORE the checkpoint (Step 7)
+  # so every durable artefact lands in the same atomic write.
+  verdict = "pass" if all axes >= threshold else "fail"
+  if verdict == "pass":
     contract.status = "done"
-    break
-
-  # Principal Skinner check (Step 7)
-  if any stop-condition fires:
+    _state.json.phase = "pr"       # transitions to "done" in Step 9
+    terminate_loop = true
+  else if any Principal Skinner stop-condition fires:
     contract.status = "aborted"
-    set _state.json.aborted_reason
-    break
+    _state.json.aborted_reason = "<condition>"
+    _state.json.phase = "impl"     # kept so resume sees the abort context
+    terminate_loop = true
+  else:
+    terminate_loop = false
+
+  # Per-iteration checkpoint (Step 7) — atomic persistence of verdict + state
+  checkpoint(iteration, start_ts, verdict, contract.status)
+
+  if terminate_loop: break
 ```
 
-Evaluator failure format (input to the next Generator call):
-
-```yaml
-iter: <n>
-verdict: fail
-failing_axes:
-  - axis: Functionality
-    score: 0.6
-    threshold: 1.0
-    notes: "AS-2 fails: login redirect 500s"
-    evidence: sprints/sprint-<n>-*/evidence/AS-2-run-<iter>.trace
-retry_hint: "Tighten session lookup; see evidence trace line 42"
-```
-
-Each iteration ends with a commit (see Step 7) so every attempt is
-reviewable in git history.
+Evaluator failure feedback (input to the next Generator call) lists
+`iter`, `verdict: fail`, a `failing_axes` array of
+`{axis, score, threshold, notes, evidence}`, and a `retry_hint` line.
+Evaluator writes this to `feedback/evaluator-<iter>.md`; Orchestrator
+passes it into the next Generator dispatch. Each iteration ends with
+a commit (Step 7) so every attempt is reviewable in git history.
 
 ### Step 7: Iteration Checkpoint and Principal Skinner (T-036, T-038)
 
-At the end of every iteration (pass OR fail OR abort), atomically:
+At the end of every iteration (pass OR fail OR abort), persist verdict
+and state in a single atomic pass so a crash between any two writes
+leaves resume deterministic:
 
-1. **Update `_state.json`** via `jq` into a tmp file, then rename:
+1. **Update `contract.md`** when `verdict == "pass"` or Principal
+   Skinner fired: set frontmatter `status: done | aborted`, fill the
+   `Sprint Outcome` section (final iteration, last commit hint,
+   aborted reason if any).
+
+2. **Update `_state.json`** via `jq` into a tmp file, then rename:
    - `iteration`, `last_agent`, `next_action`, `last_commit`
+   - `phase` (impl → evaluation → pr on pass, or kept with
+     `aborted_reason` set on Principal Skinner hit)
    - `features_pass_fail` (per-axis for this sprint's features)
    - `cumulative_cost_usd += cost_this_iter`
-   - `rubric_stagnation_count` — increment if no axis improved this iter; reset to 0 on any improvement
+   - `rubric_stagnation_count` — increment if no axis improved this
+     iter; reset to 0 on any improvement
+   - `aborted_reason` if Principal Skinner fired
 
-2. **Append one line to `.harness/metrics.jsonl`**:
+3. **Append one line to `.harness/metrics.jsonl`**:
    ```json
    {"ts":"<ISO>","iter":<n>,"sprint":<s>,"agent":"<role>","duration_ms":<d>,"input_tokens":<i>,"output_tokens":<o>,"cost_usd":<c>,"rubric_scores":{...},"tool_calls":<t>,"tool_failures":<f>}
    ```
 
-3. **Commit**: `git add -A && git commit -m "harness-loop: sprint-<n> iter-<iter>"` (non-fatal on `git commit` failure; log to progress.md and continue).
+4. **Commit**: `git add -A && git commit -m "harness-loop: sprint-<n> iter-<iter>"` captures the contract.md status change, feedback files for this iteration, evidence artefacts, and the state/metrics updates in one commit (non-fatal on `git commit` failure; log to progress.md and continue).
 
-4. **Principal Skinner stop-check** — evaluate all five conditions; on any hit set `_state.json.aborted_reason` and stop:
+5. **Principal Skinner stop-check** was performed in Step 6 (before
+   this checkpoint) so `aborted_reason` was already staged for atomic
+   write above. The five conditions:
 
    | Condition | Computed from | Default |
    |---|---|---|
@@ -272,7 +310,7 @@ At the end of every iteration (pass OR fail OR abort), atomically:
    | `cumulative_cost_usd >= max_cost_usd` | state + `_config.yml.max_cost_usd` | 20.0 |
    | `pending_human == true` | set by `.harness/scripts/tier-a-guard.sh` PreToolUse hook | — |
 
-5. Append a `progress.md` line:
+6. Append a `progress.md` line:
    ```
    [<ts>] evaluation: iter=<n> verdict=<pass|fail> axes="f=.. c=.. d=.. o=.."
    ```
@@ -284,6 +322,35 @@ At the end of every iteration (pass OR fail OR abort), atomically:
 Principal Skinner never deletes state. The loop stops and leaves
 everything on disk for a later resume (pending_human), a replan
 (rubric_stagnation), or a manual budget bump (cost_cap, wall_time).
+
+#### Interactive per-iteration gate (REQ-076)
+
+In `interactive` mode only, after the Step 7 checkpoint but before
+entering the next iteration (or Step 8 on pass), ask:
+
+```
+AskUserQuestion:
+  question: "iter=<n> verdict=<pass|fail>. Next?" /
+            "iter=<n> verdict=<pass|fail>。次は?"
+  options:
+    - "continue — run the next iteration / 次の iteration へ"
+    - "restart — /clear then resume via Boot Sequence / /clear 後に Boot Sequence で再開"
+    - "pause — exit cleanly; state preserved / 中断（state は保持）"
+    - "abort — set aborted_reason=user and stop / aborted_reason=user で停止"
+```
+
+- **continue** → loop body iterates
+- **restart** → emit user instruction ("Run `/clear` now, then re-invoke
+  `/harness-loop`; the Boot Sequence will resume from this checkpoint
+  using progress.md + _state.json + git only") and exit the skill.
+  T-054 validates that this path is fully recoverable
+- **pause** → exit 0; leave `phase` as-is
+- **abort** → set `_state.json.aborted_reason = "user"`; commit; exit
+
+`continuous`, `autonomous-ralph`, and `scheduled` modes skip this gate
+entirely (ASM-007). `continuous` proceeds immediately to the next
+iteration; Ralph/scheduled let the external wrapper decide via its own
+Principal Skinner loop.
 
 ### Step 8: PR Creation on Sprint Pass (T-034)
 
@@ -300,8 +367,12 @@ When `contract.status == "done"`:
    entry already references `bundled_with`).
 4. PR body is built from the template in `pr-creation-guide.md`, quoting
    the `shared_state.md/Evaluation` block and linking the sprint Issue
-   (`_state.json.sprint_issues[<n>]`).
-5. Record PR URL to `_state.json.sprint_issues[<n>].pr` and append
+   (`_state.json.sprint_issues[<n>]`, a URL string written by
+   `harness-plan` — see
+   `../harness-init/references/resilience-schema.md`).
+5. Record the PR URL to a new additive key `_state.json.sprint_prs[<n>]`
+   (a `sprint → PR URL` map; absent until the first PR is opened, so
+   harness-plan's `sprint_issues` contract is unchanged) and append
    `progress.md`:
    ```
    [<ts>] decision: sprint-<n> PR opened <url>
@@ -336,11 +407,9 @@ else:
   go to Step 10
 ```
 
-`cumulative_cost_usd` and `start_time`'s wall-time budget reset is a
-policy choice. v1 keeps `cumulative_cost_usd` accumulating across the
-whole epic (so the cost cap is epic-wide). `start_time` resets per
-sprint so the 8h wall-time cap applies per sprint. Document both in
-`progress.md` on reset.
+Reset policy: `cumulative_cost_usd` accumulates across the whole epic
+(cost cap is epic-wide); `start_time` resets per sprint (wall-time cap
+applies per sprint). Record both in `progress.md` on sprint transition.
 
 ### Step 10: Final Summary
 
@@ -357,9 +426,8 @@ On `completed == true`:
   ```
 - Do not touch `_state.json.completed` again. Leave for audit.
 
-Suggest `/harness-rules-update` if any sprint aborted or if
-`rubric_stagnation` fired — those are exactly the failure shapes that
-skill refines.
+Suggest `/harness-rules-update` on any abort or `rubric_stagnation`
+trigger — those failures are exactly what that skill refines.
 
 ## Error Handling
 
@@ -379,26 +447,16 @@ skill refines.
 ## Usage
 
 ```
-# Start from a planned epic
-/harness-loop
-
-# Resume after compact / restart / abort (auto-detected from _state.json)
-/harness-loop
-
-# Force a specific mode (overrides stored mode; recorded to _state.json)
-/harness-loop --mode continuous
-/harness-loop --mode autonomous-ralph
-/harness-loop --mode scheduled --ralph-every 5
-
-# Force a specific sprint (skip remaining earlier sprints; requires confirmation)
-/harness-loop --from-sprint 3
-
-# Replan aborted sprint (re-enter Negotiation, reset iteration to 0)
-/harness-loop --replan-current-sprint
+/harness-loop                                  # start or resume (auto-detect from _state.json)
+/harness-loop --mode continuous                # force mode (persists to _state.json)
+/harness-loop --mode autonomous-ralph          # exits after one iter; pair with shell wrapper
+/harness-loop --mode scheduled --ralph-every 5 # hybrid: 5 continuous iters, 1 Ralph
+/harness-loop --from-sprint 3                  # skip to sprint 3 (requires confirmation)
+/harness-loop --replan-current-sprint          # re-enter Negotiation, reset iteration to 0
 ```
 
-`--mode autonomous-ralph` exits after one iteration; pair it with the
-shell wrapper in [autonomous-ralph.md](references/autonomous-ralph.md).
+Pair `autonomous-ralph` with the wrapper in
+[autonomous-ralph.md](references/autonomous-ralph.md).
 
 ## What harness-loop does NOT do
 

--- a/skills/harness-loop/references/autonomous-ralph.ja.md
+++ b/skills/harness-loop/references/autonomous-ralph.ja.md
@@ -23,9 +23,11 @@ iter）で amortise すると Boot は経過時間の約 1%。
 
 ## ラッパースクリプトテンプレート
 
-loop 開始時にユーザが `autonomous-ralph` を選んだ時点で
-`.harness/scripts/ralph-loop.sh` として配置する。harness-init がベースを
-出荷し、harness-loop Step 2 はモード選択時のみ本ファイルを書き出す。
+以下が正準の `ralph-loop.sh`。`autonomous-ralph` を初めて選んだ時点で
+`.harness/scripts/ralph-loop.sh` に配置する（`harness-loop` の Step 2
+がモード選択時に書き出す。v1 では `harness-init` は出荷しない）。
+プロジェクトごとに 1 ファイル運用で、プロジェクト側の修正は git で
+バージョン管理した場合のみ再インストール後も維持される。
 
 ```bash
 #!/usr/bin/env bash
@@ -145,8 +147,10 @@ while :; do
 done
 ```
 
-`_config.yml.scheduled_ralph_every` で `RALPH_EVERY` を設定（デフォルト 5）。
-`harness-init` が `scheduled` 選択可能時に setup 時に記録する。
+`RALPH_EVERY` の解決順序: `/harness-loop` 呼び出し時の
+`--ralph-every <N>` CLI フラグ → `RALPH_EVERY` 環境変数 → リテラル
+デフォルト `5`。v1 では `_config.yml` から読まない
+（`harness-init` は本キーを把握していない）。
 
 ## 夜間運用
 

--- a/skills/harness-loop/references/autonomous-ralph.ja.md
+++ b/skills/harness-loop/references/autonomous-ralph.ja.md
@@ -1,0 +1,193 @@
+# Autonomous Ralph
+
+REQ-078 と REQ-079 を扱う。`autonomous-ralph` 実行モードは `harness-loop` を
+headless で回し、各 iteration を独立 Claude プロセスで実行する。
+iteration 間の記憶は `progress.md` + `_state.json` + git + `metrics.jsonl`
+の 4 ファイルのみ。"Ralph" は checkpoint された状態に対して fresh agent を
+繰り返し起動するこのパターンの通称。
+
+## なぜ iteration 毎に fresh context か
+
+単一の長時間 `claude -p --continue` セッションはコンテキスト蓄積で
+compaction を引き起こす。harness ループでは Generator 出力・Evaluator
+採点・ツール出力が毎 iter 積層するため影響が大きい。iter 毎再起動で
+drift を排除する:
+
+- 各 iter は 3 つの永続ファイルのみを読む
+- Principal Skinner 条件が唯一の生存する iter 跨ぎ状態
+- 再現性: 過去 iter の入力を再実行すれば同一出力クラスが得られる
+  （モデル温度の範囲で）
+
+トレードオフ: iter 毎の Boot Sequence コスト。sprint 全体（デフォルト 8
+iter）で amortise すると Boot は経過時間の約 1%。
+
+## ラッパースクリプトテンプレート
+
+loop 開始時にユーザが `autonomous-ralph` を選んだ時点で
+`.harness/scripts/ralph-loop.sh` として配置する。harness-init がベースを
+出荷し、harness-loop Step 2 はモード選択時のみ本ファイルを書き出す。
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE=".harness/_state.json"
+PROGRESS=".harness/progress.md"
+
+command -v jq >/dev/null || { echo "jq required" >&2; exit 2; }
+command -v claude >/dev/null || { echo "claude CLI required" >&2; exit 2; }
+[[ -f $STATE ]] || { echo "_state.json missing; run /harness-init + /harness-plan first" >&2; exit 2; }
+
+while :; do
+  # Principal Skinner ゲート — すべて _state.json から読む
+  completed=$(jq -r '.completed // false' "$STATE")
+  aborted=$(jq -r '.aborted_reason // empty' "$STATE")
+  pending_human=$(jq -r '.pending_human // false' "$STATE")
+  iter=$(jq -r '.iteration // 0' "$STATE")
+  max_iter=$(jq -r '.max_iterations // 8' "$STATE")
+  start_time=$(jq -r '.start_time // empty' "$STATE")
+  max_wall=$(jq -r '.max_wall_time_sec // 28800' "$STATE")
+  cost=$(jq -r '.cumulative_cost_usd // 0' "$STATE")
+  max_cost=$(jq -r '.max_cost_usd // 20' "$STATE")
+  stag=$(jq -r '.rubric_stagnation_count // 0' "$STATE")
+  max_stag=$(jq -r '.rubric_stagnation_n // 3' "$STATE")
+
+  if [[ $completed == true ]]; then
+    printf '[%s] ralph: epic complete, exiting\n' "$(date -u +%FT%TZ)" >> "$PROGRESS"
+    exit 0
+  fi
+  if [[ -n $aborted ]]; then
+    printf '[%s] ralph: aborted reason=%s; human resume required\n' "$(date -u +%FT%TZ)" "$aborted" >> "$PROGRESS"
+    exit 1
+  fi
+  if [[ $pending_human == true ]]; then
+    printf '[%s] ralph: pending_human=true; halting for approval\n' "$(date -u +%FT%TZ)" >> "$PROGRESS"
+    exit 1
+  fi
+  if (( iter >= max_iter )); then
+    jq '.aborted_reason = "max_iterations"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+    printf '[%s] stop: reason=max_iter iter=%s\n' "$(date -u +%FT%TZ)" "$iter" >> "$PROGRESS"
+    exit 1
+  fi
+  # wall_time
+  if [[ -n $start_time ]]; then
+    elapsed=$(( $(date -u +%s) - $(date -u -j -f %FT%TZ "$start_time" +%s 2>/dev/null || date -u -d "$start_time" +%s) ))
+    if (( elapsed >= max_wall )); then
+      jq '.aborted_reason = "wall_time"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+      printf '[%s] stop: reason=wall_time elapsed=%ss\n' "$(date -u +%FT%TZ)" "$elapsed" >> "$PROGRESS"
+      exit 1
+    fi
+  fi
+  # cost cap
+  if awk -v c="$cost" -v m="$max_cost" 'BEGIN{exit !(c>=m)}'; then
+    jq '.aborted_reason = "cost_cap"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+    printf '[%s] stop: reason=cost_cap cost=%s\n' "$(date -u +%FT%TZ)" "$cost" >> "$PROGRESS"
+    exit 1
+  fi
+  # rubric stagnation
+  if (( stag >= max_stag )); then
+    jq '.aborted_reason = "rubric_stagnation"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+    printf '[%s] stop: reason=rubric_stagnation count=%s\n' "$(date -u +%FT%TZ)" "$stag" >> "$PROGRESS"
+    exit 1
+  fi
+
+  # 1 iteration、fresh context
+  printf '[%s] ralph: launching iter=%s\n' "$(date -u +%FT%TZ)" "$iter" >> "$PROGRESS"
+  claude -p --bare "Resume /harness-loop. Read .harness/progress.md (tail 100) and .harness/_state.json. Execute exactly one iteration (one Generator turn + one Evaluator turn + Step 7 checkpoint), then exit."
+  # skill が呼び出し内で _state.json を書く; 次 tick で新値が読まれる
+done
+```
+
+### 終了コード
+
+| Code | 意味 |
+|---|---|
+| 0 | epic 完了、終了 |
+| 1 | Principal Skinner 停止 または pending_human halt |
+| 2 | Pre-flight 失敗（jq / claude / `_state.json` 不足） |
+
+## なぜ `--bare`、`--continue`/`--resume` 不使用か
+
+- `--bare`: インタラクティブ UI と追加フレーミングを抑制。stdout の
+  shell 捕捉が決定論的
+- `--continue` 不使用: 各呼び出しが fresh context。Ralph は *fresh context
+  そのもの* であり、過去セッション継承はパターンを台無しにする
+- `--resume` 不使用: 古いコンテキストを stitch し直すため同じ論理
+
+harness パターンの前提: 3 つの永続ファイルが再開に必要なものを全て
+持つ。持てない場合は Orchestrator の状態書込のバグであり、セッション
+メモリを残す理由にはならない。
+
+## Scheduled モード変形
+
+`scheduled` はハイブリッド。`continuous` を N iter 回したあと `autonomous-ralph`
+を 1 iter 挟んでコンテキストを流す、を繰り返す。プロジェクトが pure
+continuous には大きすぎ（sprint 中 context rot）、pure Ralph では Boot
+コストが支配的な場合に使う。
+
+```bash
+# ralph-loop.sh の変形:
+RALPH_EVERY=${RALPH_EVERY:-5}
+continuous_iters_remaining=${RALPH_EVERY}
+
+while :; do
+  # ...上記と同じ Principal Skinner ゲート...
+
+  if (( continuous_iters_remaining > 0 )); then
+    # continuous 1 step: 同一 claude セッションを維持
+    claude -p --bare "..."  # orchestrator が同一プロセスで 1 iter 進める
+    continuous_iters_remaining=$(( continuous_iters_remaining - 1 ))
+  else
+    # Ralph 1 step: fresh context
+    claude -p --bare "Resume /harness-loop one iteration..."
+    continuous_iters_remaining=${RALPH_EVERY}
+  fi
+done
+```
+
+`_config.yml.scheduled_ralph_every` で `RALPH_EVERY` を設定（デフォルト 5）。
+`harness-init` が `scheduled` 選択可能時に setup 時に記録する。
+
+## 夜間運用
+
+数時間〜夜間実行する場合:
+
+1. loop 開始時に `autonomous-ralph` を選択
+2. `max_wall_time_sec` を予算に合わせて設定
+   （例: 8h なら 28800、デフォルト）
+3. `max_cost_usd` でコスト上限
+   （例: $20 なら 20、デフォルト）
+4. ラッパーを detach で起動:
+   ```bash
+   nohup .harness/scripts/ralph-loop.sh >> .harness/ralph.log 2>&1 &
+   disown
+   ```
+5. モニタ:
+   ```bash
+   tail -f .harness/progress.md
+   tail -f .harness/metrics.jsonl
+   ```
+
+起床後: `_state.json` の `aborted_reason` を最初に確認、次に
+`progress.md` の末尾。
+
+## Ralph 実行中の Tier-A 停止
+
+`.harness/scripts/tier-a-guard.sh`（`harness-init` が配置）は Tier-A 操作を
+deny した時 `pending_human=true` に設定する。ラッパーの次 tick でこれを
+検出し、Claude プロセスを新規起動せず exit 1 する。ユーザは:
+
+1. deny されたコマンドを `progress.md` で確認
+2. 判断: approve（方針調整）または reject（aborted のまま）
+3. 手動で `_state.json.pending_human=false` に戻す
+4. ラッパー再起動
+
+バイパス経路は無い。Tier-A 承認は常に human-in-the-loop（REQ-081）。
+
+## やってはいけないこと
+
+- `while :; do claude -p --continue ...` — Ralph を台無しにする
+- Principal Skinner ブロックの抑制 — コスト暴走
+- iteration の並列化 — state ファイルがボトルネック
+- 同一プロジェクトで複数ラッパーを起動 — `_state.json` race
+- 本番でラッパー stderr を握り潰す — 診断材料の損失

--- a/skills/harness-loop/references/autonomous-ralph.md
+++ b/skills/harness-loop/references/autonomous-ralph.md
@@ -23,9 +23,11 @@ sprint (8 iter default), Boot is ~1% of elapsed time.
 
 ## Wrapper script template
 
-Install as `.harness/scripts/ralph-loop.sh` when the user picks
-`autonomous-ralph` at loop start. harness-init ships the baseline;
-harness-loop Step 2 writes this file only when mode is selected.
+The template below is the authoritative `ralph-loop.sh`. Install it at
+`.harness/scripts/ralph-loop.sh` the first time `autonomous-ralph` is
+selected (`harness-loop` Step 2 writes it on mode selection; it is not
+shipped by `harness-init` in v1). Keep one copy per project — a
+project-local edit survives re-installs only if you version it in git.
 
 ```bash
 #!/usr/bin/env bash
@@ -145,9 +147,10 @@ while :; do
 done
 ```
 
-`_config.yml.scheduled_ralph_every` sets `RALPH_EVERY` (default 5).
-`harness-init` records this at setup time when `scheduled` is
-selectable.
+`RALPH_EVERY` comes from (in order): the `--ralph-every <N>` CLI flag
+passed to `/harness-loop`, the `RALPH_EVERY` env var, or the literal
+default `5`. v1 does not read this from `_config.yml`; `harness-init`
+is not aware of the key.
 
 ## Running overnight
 

--- a/skills/harness-loop/references/autonomous-ralph.md
+++ b/skills/harness-loop/references/autonomous-ralph.md
@@ -1,0 +1,195 @@
+# Autonomous Ralph
+
+Covers REQ-078 and REQ-079. The `autonomous-ralph` execution mode
+runs `harness-loop` headlessly, one iteration per Claude process,
+with no cross-iteration memory except `progress.md` + `_state.json` +
+git + `metrics.jsonl`. "Ralph" is the canonical name for this pattern
+(repeatedly re-invoking a fresh agent on the same checkpointed state).
+
+## Why fresh context per iteration
+
+A single long-running `claude -p --continue` session accumulates
+context until compaction hits. Harnessed loops magnify this because
+each iteration layers Generator output, Evaluator scoring, and tool
+output on top. Restarting per iteration eliminates that drift:
+
+- Each iteration reads only the three durable files
+- Principal Skinner conditions are the only surviving cross-iter state
+- Reproducibility: rerunning a prior iteration's input yields the same
+  output class (subject to model temperature)
+
+Tradeoff: Boot Sequence cost per iter. Amortised against a full
+sprint (8 iter default), Boot is ~1% of elapsed time.
+
+## Wrapper script template
+
+Install as `.harness/scripts/ralph-loop.sh` when the user picks
+`autonomous-ralph` at loop start. harness-init ships the baseline;
+harness-loop Step 2 writes this file only when mode is selected.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE=".harness/_state.json"
+PROGRESS=".harness/progress.md"
+
+command -v jq >/dev/null || { echo "jq required" >&2; exit 2; }
+command -v claude >/dev/null || { echo "claude CLI required" >&2; exit 2; }
+[[ -f $STATE ]] || { echo "_state.json missing; run /harness-init + /harness-plan first" >&2; exit 2; }
+
+while :; do
+  # Principal Skinner gates — all read from _state.json
+  completed=$(jq -r '.completed // false' "$STATE")
+  aborted=$(jq -r '.aborted_reason // empty' "$STATE")
+  pending_human=$(jq -r '.pending_human // false' "$STATE")
+  iter=$(jq -r '.iteration // 0' "$STATE")
+  max_iter=$(jq -r '.max_iterations // 8' "$STATE")
+  start_time=$(jq -r '.start_time // empty' "$STATE")
+  max_wall=$(jq -r '.max_wall_time_sec // 28800' "$STATE")
+  cost=$(jq -r '.cumulative_cost_usd // 0' "$STATE")
+  max_cost=$(jq -r '.max_cost_usd // 20' "$STATE")
+  stag=$(jq -r '.rubric_stagnation_count // 0' "$STATE")
+  max_stag=$(jq -r '.rubric_stagnation_n // 3' "$STATE")
+
+  if [[ $completed == true ]]; then
+    printf '[%s] ralph: epic complete, exiting\n' "$(date -u +%FT%TZ)" >> "$PROGRESS"
+    exit 0
+  fi
+  if [[ -n $aborted ]]; then
+    printf '[%s] ralph: aborted reason=%s; human resume required\n' "$(date -u +%FT%TZ)" "$aborted" >> "$PROGRESS"
+    exit 1
+  fi
+  if [[ $pending_human == true ]]; then
+    printf '[%s] ralph: pending_human=true; halting for approval\n' "$(date -u +%FT%TZ)" >> "$PROGRESS"
+    exit 1
+  fi
+  if (( iter >= max_iter )); then
+    jq '.aborted_reason = "max_iterations"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+    printf '[%s] stop: reason=max_iter iter=%s\n' "$(date -u +%FT%TZ)" "$iter" >> "$PROGRESS"
+    exit 1
+  fi
+  # wall_time
+  if [[ -n $start_time ]]; then
+    elapsed=$(( $(date -u +%s) - $(date -u -j -f %FT%TZ "$start_time" +%s 2>/dev/null || date -u -d "$start_time" +%s) ))
+    if (( elapsed >= max_wall )); then
+      jq '.aborted_reason = "wall_time"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+      printf '[%s] stop: reason=wall_time elapsed=%ss\n' "$(date -u +%FT%TZ)" "$elapsed" >> "$PROGRESS"
+      exit 1
+    fi
+  fi
+  # cost cap
+  if awk -v c="$cost" -v m="$max_cost" 'BEGIN{exit !(c>=m)}'; then
+    jq '.aborted_reason = "cost_cap"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+    printf '[%s] stop: reason=cost_cap cost=%s\n' "$(date -u +%FT%TZ)" "$cost" >> "$PROGRESS"
+    exit 1
+  fi
+  # rubric stagnation
+  if (( stag >= max_stag )); then
+    jq '.aborted_reason = "rubric_stagnation"' "$STATE" > "$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+    printf '[%s] stop: reason=rubric_stagnation count=%s\n' "$(date -u +%FT%TZ)" "$stag" >> "$PROGRESS"
+    exit 1
+  fi
+
+  # One iteration, fresh context
+  printf '[%s] ralph: launching iter=%s\n' "$(date -u +%FT%TZ)" "$iter" >> "$PROGRESS"
+  claude -p --bare "Resume /harness-loop. Read .harness/progress.md (tail 100) and .harness/_state.json. Execute exactly one iteration (one Generator turn + one Evaluator turn + Step 7 checkpoint), then exit."
+  # The skill writes _state.json inside the call; this loop reads fresh values next tick.
+done
+```
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Epic completed; nothing to do |
+| 1 | Principal Skinner stop or pending_human halt |
+| 2 | Pre-flight failed (missing jq / claude / `_state.json`) |
+
+## Why `--bare` and no `--continue`/`--resume`
+
+- `--bare`: suppresses interactive UI and extra framing. Deterministic
+  for shell capture of stdout
+- No `--continue`: every invocation is fresh context. Ralph *is* fresh
+  context; inheriting a prior session defeats the pattern
+- No `--resume`: resume stitches old context back in — same objection
+
+The harness pattern is: the three durable files carry everything
+necessary to pick up. If they can't, we have a bug in the Orchestrator's
+state writing, not a reason to keep session memory.
+
+## Scheduled mode variant
+
+`scheduled` is the hybrid: run `continuous` for N iterations, then
+one `autonomous-ralph` iteration to flush context, repeat. Use when
+the project is too large for pure continuous (context rot mid-sprint)
+but pure Ralph's Boot cost dominates.
+
+```bash
+# ralph-loop.sh but with:
+RALPH_EVERY=${RALPH_EVERY:-5}
+continuous_iters_remaining=${RALPH_EVERY}
+
+while :; do
+  # ...Principal Skinner gates as above...
+
+  if (( continuous_iters_remaining > 0 )); then
+    # one continuous step: keep the same claude session
+    claude -p --bare "..."  # orchestrator advances 1 iter in same process
+    continuous_iters_remaining=$(( continuous_iters_remaining - 1 ))
+  else
+    # one Ralph step: fresh context
+    claude -p --bare "Resume /harness-loop one iteration..."
+    continuous_iters_remaining=${RALPH_EVERY}
+  fi
+done
+```
+
+`_config.yml.scheduled_ralph_every` sets `RALPH_EVERY` (default 5).
+`harness-init` records this at setup time when `scheduled` is
+selectable.
+
+## Running overnight
+
+For overnight or multi-hour runs:
+
+1. Pick `autonomous-ralph` at loop start
+2. Ensure `max_wall_time_sec` matches your budget
+   (e.g., 28800 for 8h, the default)
+3. Ensure `max_cost_usd` caps spend
+   (e.g., 20 for $20, the default)
+4. Start the wrapper detached:
+   ```bash
+   nohup .harness/scripts/ralph-loop.sh >> .harness/ralph.log 2>&1 &
+   disown
+   ```
+5. Monitor via:
+   ```bash
+   tail -f .harness/progress.md
+   tail -f .harness/metrics.jsonl
+   ```
+
+On wake: inspect `aborted_reason` in `_state.json` first, then
+`progress.md` tail.
+
+## Tier-A halts during Ralph
+
+`.harness/scripts/tier-a-guard.sh` (installed by `harness-init`) sets
+`pending_human=true` when it denies a Tier-A operation. The wrapper's
+next tick sees this and exits 1 without launching a new Claude
+process. The user:
+
+1. Inspects the denied command in `progress.md`
+2. Decides: approve (edit the approach) or reject (leave aborted)
+3. Manually resets `pending_human=false` in `_state.json`
+4. Restarts the wrapper
+
+No bypass path. Tier-A approval is always human-in-the-loop (REQ-081).
+
+## Don't do
+
+- Don't `while :; do claude -p --continue ...` — defeats Ralph
+- Don't suppress the Principal Skinner block — runaway cost
+- Don't parallelise iterations — the state file is the bottleneck
+- Don't run two wrappers on the same project — race on `_state.json`
+- Don't swallow the wrapper's stderr in production — missed diagnostics

--- a/skills/harness-loop/references/negotiation-protocol.ja.md
+++ b/skills/harness-loop/references/negotiation-protocol.ja.md
@@ -123,7 +123,7 @@ Orchestrator は Planner に以下を含む単一プロンプトを渡す:
 2. 各 `feedback/generator-<r>.md`（round 1..3）
 3. 各 `feedback/evaluator-<r>.md`（round 1..3）
 4. 該当する rubric プリセット
-   (`../../rubric-presets.ja.md#<project-type>`)
+   (`../../harness-init/references/rubric-presets.ja.md#<project-type>`)
 5. 固定指示:
 
 ```

--- a/skills/harness-loop/references/negotiation-protocol.ja.md
+++ b/skills/harness-loop/references/negotiation-protocol.ja.md
@@ -1,0 +1,225 @@
+# Negotiation Protocol（交渉プロトコル）
+
+REQ-031 を扱う。各 sprint は Generator と Evaluator の有限交渉から始まり、
+contract の rubric・閾値・`max_iterations` を合意する。3 往復で合意に
+至らない場合は Planner が強制裁定する。
+
+## 参加者と書き込み権限
+
+| Agent | 読み取り | 交渉中の書き込み |
+|---|---|---|
+| Generator | `contract.md`, `shared_state.md`, `feedback/evaluator-<r>.md` | `feedback/generator-<r>.md` |
+| Evaluator | `contract.md`, `shared_state.md`, `feedback/generator-<r>.md` | `feedback/evaluator-<r>.md` |
+| Planner | 上記すべて | `feedback/planner-ruling.md` → `contract.md` の ruling セクション |
+| Orchestrator (harness-loop) | すべて | `shared_state.md/Negotiation`, `contract.md` frontmatter 凍結 |
+
+`shared_state.md` への書き込みは Orchestrator のみ。ラウンド要約を台帳に転記
+することで、sprint に対する単一の監査証跡を保持する
+（詳細は [shared-state-protocol.ja.md](shared-state-protocol.ja.md)）。
+
+## ラウンド構造
+
+1 ラウンド = Generator 発話 → Evaluator 発話。ラウンド番号は 1 起点。
+上限は `contract.max_negotiation_rounds`（デフォルト 3、`_config.yml` で上書き可）。
+
+### Round N のスキーマ
+
+各側が提案ドキュメントを出す。Orchestrator は**順次**（並列禁止）で
+dispatch する。後攻は先攻の提案を参照する必要があるため。
+
+**Generator ラウンドファイル** (`feedback/generator-<r>.md`):
+
+```yaml
+---
+round: <r>
+role: generator
+ts: <ISO-8601-UTC>
+---
+
+## Proposed contract delta
+
+<!--
+  ドラフトから変更したいフィールドのみ記述。
+  変更なしなら `unchanged` と書くか省略。
+-->
+
+rubric:
+  - axis: Functionality
+    threshold: 0.95   # was 1.0
+    reason: "login リダイレクトの flakiness。1.0 の代わりに retry harness を提案"
+max_iterations: 8     # unchanged
+
+## Trade-offs acknowledged
+
+<!--
+  delta と引き換えに Generator が譲歩する内容。
+-->
+
+- Craft 側で明示的な retry + a11y snapshot 差分検証を追加する
+
+## Open risks
+
+<!--
+  Generator が不確実で、Evaluator に解消してほしい点。
+-->
+
+- login モーダルで Playwright a11y snapshot が決定論的か不確か。
+  Evaluator の意見を仰ぎたい
+
+## Agreement signal
+
+`propose` | `accept` | `reject`
+```
+
+**Evaluator ラウンドファイル** (`feedback/evaluator-<r>.md`):
+同じスキーマで `role: evaluator`。
+
+合意シグナル:
+
+- `propose` — 交渉継続。counter-proposal を同一ファイルに含める
+- `accept` — 相手の直近提案を明示的に受諾
+- `reject` — counter なしで拒否。Planner 裁定を強制するための稀なシグナル
+  （Round N+1 に材料を残すため原則 `propose` 推奨）
+
+### ラウンド結果マトリクス
+
+| Generator シグナル | Evaluator シグナル | 結果 |
+|---|---|---|
+| `accept` | any | Evaluator の直近提案が採択、交渉終了 |
+| any | `accept` | Generator の直近提案が採択、交渉終了 |
+| `propose` | `propose` | Round + 1（上限内なら）、上限なら Planner 裁定 |
+| `reject` | any | 同上 |
+| any | `reject` | 同上 |
+
+両者が同一ラウンドで同じ提案を `accept` した場合、Orchestrator は
+相互合意として扱う。
+
+### Orchestrator サマリ行
+
+各ラウンド後、Orchestrator は `shared_state.md/Negotiation` に**2 行**
+（speaker 毎）を追記する:
+
+```
+- [<ts>] round=<r> agent=generator signal=<propose|accept|reject> delta=<短い要約> file=feedback/generator-<r>.md
+- [<ts>] round=<r> agent=evaluator signal=<propose|accept|reject> delta=<短い要約> file=feedback/evaluator-<r>.md
+```
+
+ラウンド終了毎に `progress.md` に 1 行:
+
+```
+[<ts>] negotiation: round=<r> generator=<signal> evaluator=<signal>
+```
+
+## 3 ラウンド上限と Planner 裁定
+
+`round == max_negotiation_rounds` に達してもどちらも `accept` を出していない場合、
+Orchestrator は Planner に全交渉パケットを渡して拘束力のある裁定を依頼する。
+
+### Planner 入力パケット
+
+Orchestrator は Planner に以下を含む単一プロンプトを渡す:
+
+1. `contract.md` の現ドラフト（frontmatter + acceptance scenarios）
+2. 各 `feedback/generator-<r>.md`（round 1..3）
+3. 各 `feedback/evaluator-<r>.md`（round 1..3）
+4. 該当する rubric プリセット
+   (`../../rubric-presets.ja.md#<project-type>`)
+5. 固定指示:
+
+```
+あなたは停滞した交渉を裁定する Planner です。最終 contract delta を
+feedback/planner-ruling.md に書き出してください。論理的・拘束的・
+軸毎に 1 つの rubric。さらなる交渉提案はしてはいけません。
+```
+
+### Planner 裁定ファイル (`feedback/planner-ruling.md`)
+
+```yaml
+---
+role: planner
+ts: <ISO-8601-UTC>
+---
+
+## Ruling
+
+rubric:
+  - axis: Functionality
+    weight: high
+    threshold: 1.0
+  - axis: Craft
+    weight: std
+    threshold: 0.8    # redirect リスクを踏まえ 0.7 から引き上げ
+  - axis: Design
+    weight: std
+    threshold: 0.7
+  - axis: Originality
+    weight: low
+    threshold: 0.5
+max_iterations: 10     # retry 分を吸収するため 8 から引き上げ
+
+## Reasoning
+
+Generator の retry harness 論は妥当。Evaluator の Craft 水準引き上げは
+トレードとして受諾。
+
+## Applies to
+
+sprint: <N>
+feature: <feature-name>
+```
+
+### 裁定後の contract 凍結
+
+Orchestrator は:
+
+1. 裁定内容を `contract.md` frontmatter に書き込む
+2. Planner の `## Ruling` セクションを `contract.md` の
+   `## Negotiation Log > ### Ruling` セクションへ逐語転記
+3. `contract.status: active` に設定
+4. commit: `git commit -m "harness-loop: sprint-<n> Planner ruling"`
+5. `progress.md` に追記:
+   ```
+   [<ts>] decision: sprint-<n> negotiation ruled by Planner (rounds=3)
+   ```
+
+## 交渉中のアンチパターン（却下対象）
+
+- **交渉ファイル内でのコード提案** — 交渉対象は rubric / threshold /
+  `max_iterations` / scenario 数のみ。実装選択は SKILL flow Step 6 の領域
+- **rubric 軸の勝手な追加** — v1 はプロジェクト種別のプリセット固定
+- **Functionality の threshold 0.5 未満** — Principal Skinner の
+  rubric-stagnation を空振りで起こす。スコープ分割を要求して却下
+- **`max_cost_usd` / `max_wall_time_sec` の交渉** — これらは
+  `_config.yml` の Principal Skinner caps であり sprint スコープ外。
+  `/harness-init` 再構成で変更
+- **シグナル未記載** — `Agreement signal` 行を欠く提案は `propose` 扱い
+  だが malformed としてログ
+
+## Resume 挙動
+
+交渉中にスキルが再起動された場合、Orchestrator は
+`_state.json.phase == "negotiation"` と最大番号の
+`feedback/{generator|evaluator}-<r>.md` ペアを読む。次のアクションは
+欠けている側の発話、両者揃っていれば Round N+1、N が上限なら Planner 裁定。
+
+すべてのラウンドファイルは書き込み後不可侵（in-place 編集禁止）。
+修正が必要なら round 番号を増やして追加する（progress.md の
+append-only 原則と一致）。
+
+## テストレシピ
+
+```bash
+# 試走: Generator propose → Evaluator accept
+claude -p --agent generator "propose round 1 for sprint-1/contract.md"
+# → feedback/generator-1.md（signal=propose）
+
+claude -p --agent evaluator "review feedback/generator-1.md and signal"
+# → feedback/evaluator-1.md（signal=accept）
+
+# Orchestrator が contract 凍結
+jq '.phase="impl"' .harness/_state.json > /tmp/s && mv /tmp/s .harness/_state.json
+```
+
+成功条件: `contract.md.status == "active"`、`contract.md` の
+`Negotiation Log / Round 1` に両メッセージ、`shared_state.md/Negotiation`
+に Orchestrator サマリ 2 行が揃う。

--- a/skills/harness-loop/references/negotiation-protocol.md
+++ b/skills/harness-loop/references/negotiation-protocol.md
@@ -126,7 +126,8 @@ The Orchestrator passes the Planner a single prompt containing:
 1. `contract.md` current draft (frontmatter + acceptance scenarios)
 2. Each `feedback/generator-<r>.md` (rounds 1..3)
 3. Each `feedback/evaluator-<r>.md` (rounds 1..3)
-4. The relevant rubric preset (`../../rubric-presets.md#<project-type>`)
+4. The relevant rubric preset
+   (`../../harness-init/references/rubric-presets.md#<project-type>`)
 5. A fixed instruction:
 
 ```

--- a/skills/harness-loop/references/negotiation-protocol.md
+++ b/skills/harness-loop/references/negotiation-protocol.md
@@ -1,0 +1,231 @@
+# Negotiation Protocol
+
+Covers REQ-031. Every sprint begins with a bounded negotiation between
+Generator and Evaluator over the contract rubric, thresholds, and
+`max_iterations`. After three rounds without agreement the Planner
+forces a ruling.
+
+## Participants and write permissions
+
+| Agent | Reads | Writes during negotiation |
+|---|---|---|
+| Generator | `contract.md`, `shared_state.md`, `feedback/evaluator-<r>.md` | `feedback/generator-<r>.md` |
+| Evaluator | `contract.md`, `shared_state.md`, `feedback/generator-<r>.md` | `feedback/evaluator-<r>.md` |
+| Planner | everything above | `feedback/planner-ruling.md`, then `contract.md` ruling section |
+| Orchestrator (harness-loop) | everything | `shared_state.md/Negotiation`, `contract.md` frontmatter freeze |
+
+No agent writes `shared_state.md`. The Orchestrator copies round
+summaries into the ledger so the sprint has a single canonical audit
+trail (see [shared-state-protocol.md](shared-state-protocol.md)).
+
+## Round structure
+
+One round = one Generator turn followed by one Evaluator turn. Rounds
+are numbered from 1. The cap is `contract.max_negotiation_rounds`
+(default 3, overridable in `_config.yml`).
+
+### Round N schema
+
+Each side produces a proposal document. The Orchestrator dispatches
+them sequentially, not in parallel — the second speaker must see the
+first's proposal.
+
+**Generator round file** (`feedback/generator-<r>.md`):
+
+```yaml
+---
+round: <r>
+role: generator
+ts: <ISO-8601-UTC>
+---
+
+## Proposed contract delta
+
+<!--
+  Only the fields the Generator wants to change from the draft.
+  Use `unchanged` or omit if none.
+-->
+
+rubric:
+  - axis: Functionality
+    threshold: 0.95   # was 1.0
+    reason: "Flaky login redirect; proposes retry harness instead of 1.0"
+max_iterations: 8     # unchanged
+
+## Trade-offs acknowledged
+
+<!--
+  What the Generator concedes in exchange for the delta.
+-->
+
+- Will add explicit retry + a11y snapshot diffing under Craft
+
+## Open risks
+
+<!--
+  Things the Generator is unsure about; inputs Evaluator can help resolve.
+-->
+
+- Uncertain whether Playwright a11y snapshot is deterministic on login
+  modal; would like Evaluator's opinion
+
+## Agreement signal
+
+`propose` | `accept` | `reject`
+```
+
+**Evaluator round file** (`feedback/evaluator-<r>.md`): same schema,
+`role: evaluator`.
+
+Agreement signals:
+
+- `propose` — still negotiating; counter-proposal included above
+- `accept` — explicitly accepts the other side's most recent proposal
+- `reject` — rejects without counter; use only to force Planner ruling
+  (rare; prefer `propose` so Round N+1 has material)
+
+### Round outcome matrix
+
+| Generator signal | Evaluator signal | Result |
+|---|---|---|
+| `accept` | anything | Evaluator's last proposal wins; exit negotiation |
+| anything | `accept` | Generator's last proposal wins; exit negotiation |
+| `propose` | `propose` | Round + 1 (if room), else Planner ruling |
+| `reject` | anything | Round + 1 (if room), else Planner ruling |
+| anything | `reject` | Round + 1 (if room), else Planner ruling |
+
+When both sides `accept` the same proposal in the same round, the
+Orchestrator treats that as mutual agreement.
+
+### Orchestrator summary lines
+
+After each round the Orchestrator appends **two** lines to
+`shared_state.md/Negotiation` — one per speaker:
+
+```
+- [<ts>] round=<r> agent=generator signal=<propose|accept|reject> delta=<short phrase> file=feedback/generator-<r>.md
+- [<ts>] round=<r> agent=evaluator signal=<propose|accept|reject> delta=<short phrase> file=feedback/evaluator-<r>.md
+```
+
+And one `progress.md` line per round end:
+
+```
+[<ts>] negotiation: round=<r> generator=<signal> evaluator=<signal>
+```
+
+## 3-round cap and Planner ruling
+
+If `round == max_negotiation_rounds` and neither side has signalled
+`accept`, the Orchestrator dispatches the Planner with the full
+negotiation packet and asks for a binding ruling.
+
+### Planner input packet
+
+The Orchestrator passes the Planner a single prompt containing:
+
+1. `contract.md` current draft (frontmatter + acceptance scenarios)
+2. Each `feedback/generator-<r>.md` (rounds 1..3)
+3. Each `feedback/evaluator-<r>.md` (rounds 1..3)
+4. The relevant rubric preset (`../../rubric-presets.md#<project-type>`)
+5. A fixed instruction:
+
+```
+You are the Planner ruling on a stalled negotiation. Write
+feedback/planner-ruling.md with the final contract delta. Reasoned,
+binding, one rubric per axis. Do not propose further negotiation.
+```
+
+### Planner ruling file (`feedback/planner-ruling.md`)
+
+```yaml
+---
+role: planner
+ts: <ISO-8601-UTC>
+---
+
+## Ruling
+
+rubric:
+  - axis: Functionality
+    weight: high
+    threshold: 1.0
+  - axis: Craft
+    weight: std
+    threshold: 0.8    # lifted from proposed 0.7 given the redirect risk
+  - axis: Design
+    weight: std
+    threshold: 0.7
+  - axis: Originality
+    weight: low
+    threshold: 0.5
+max_iterations: 10     # lifted from 8 to absorb retry work
+
+## Reasoning
+
+Generator's retry harness argument stands; Evaluator's request for a
+higher Craft bar is accepted as a trade.
+
+## Applies to
+
+sprint: <N>
+feature: <feature-name>
+```
+
+### Contract freeze after ruling
+
+The Orchestrator:
+
+1. Writes the ruling fields into `contract.md` frontmatter
+2. Copies the Planner `## Ruling` section into the contract's
+   `## Negotiation Log > ### Ruling` section, verbatim
+3. Sets `contract.status: active`
+4. Commits: `git commit -m "harness-loop: sprint-<n> Planner ruling"`
+5. Appends `progress.md`:
+   ```
+   [<ts>] decision: sprint-<n> negotiation ruled by Planner (rounds=3)
+   ```
+
+## Anti-patterns (reject during negotiation)
+
+- **Code proposals in negotiation files** — only rubric / threshold /
+  `max_iterations` / scenario count are negotiable. Implementation
+  choices belong in Step 6 of the SKILL flow.
+- **Rubric axis invention** — stick to the preset for the project type;
+  v1 does not add custom axes mid-epic.
+- **Threshold below 0.5 on Functionality** — will trip Principal Skinner
+  rubric-stagnation without progress. Reject and ask for scope split.
+- **Negotiating `max_cost_usd` / `max_wall_time_sec`** — those are
+  `_config.yml` Principal Skinner caps, not sprint-level. Edit via
+  `/harness-init` reconfigure.
+- **Unsigned `propose`** — a proposal without an `Agreement signal` line
+  is treated as `propose` but logged as malformed.
+
+## Resume behaviour
+
+On skill restart mid-negotiation the Orchestrator reads
+`_state.json.phase == "negotiation"` and the highest-numbered
+`feedback/{generator|evaluator}-<r>.md` pair. The next action is the
+other role's turn, or Round N+1 if both produced round N, or the
+Planner ruling if N equals the cap.
+
+All round files are immutable once written — no in-place edits. If a
+round needs revision, increment the round number rather than
+overwriting (append-only discipline matches progress.md).
+
+## Testing recipe
+
+```bash
+# Dry-run: ask Generator to propose, then Evaluator to accept
+claude -p --agent generator "propose round 1 for sprint-1/contract.md"
+# → writes feedback/generator-1.md with signal=propose
+
+claude -p --agent evaluator "review feedback/generator-1.md and signal"
+# → writes feedback/evaluator-1.md with signal=accept
+
+# Orchestrator freezes contract
+jq '.phase="impl"' .harness/_state.json > /tmp/s && mv /tmp/s .harness/_state.json
+```
+
+The test succeeds when `contract.md.status == "active"`, the
+`Negotiation Log / Round 1` section in `contract.md` has both messages,
+and `shared_state.md/Negotiation` has both orchestrator summary lines.

--- a/skills/harness-loop/references/otlp-exporter.ja.md
+++ b/skills/harness-loop/references/otlp-exporter.ja.md
@@ -1,0 +1,154 @@
+# OTLP Exporter（任意）
+
+REQ-092 を扱う。`.harness/metrics.jsonl` を読んで OpenTelemetry Protocol
+（OTLP）エンドポイントへ iter 毎メトリクスを転送する任意のサイドプロセス。
+コスト・rubric 推移・ツール失敗率を他プロジェクト telemetry と並べて見る
+ために用いる。
+
+有効化条件は**両方**:
+
+- `_config.yml.hook_level == "strict"`
+- `_config.yml.otlp_endpoint` が非空 URL
+
+それ以外では本 reference は情報提供。exporter スクリプト自体は出荷される
+が no-op。
+
+## インストール
+
+`harness-init` は `hook_level == strict` の時
+`.harness/scripts/metrics-exporter.sh` を配置する。スクリプトは
+idempotent ではない: 2 回起動すると cursor ファイルで tail reader が race
+する。常にプロジェクトあたり 1 インスタンスのみ動作させる。
+
+典型的なデプロイパターン:
+
+- **session スコープ** — `harness-loop` と並行起動、session 終了で停止。
+  interactive / continuous モード向け
+- **長期稼働** — macOS なら `launchd`、Linux なら `systemd --user` 配下で
+  session を越えて稼働。`autonomous-ralph` と `scheduled` モード向け
+
+## 呼び出し
+
+foreground（デバッグ用）:
+
+```bash
+.harness/scripts/metrics-exporter.sh
+```
+
+detach（夜間用）:
+
+```bash
+nohup .harness/scripts/metrics-exporter.sh >> .harness/otlp.log 2>&1 &
+disown
+```
+
+停止:
+
+```bash
+pkill -f '.harness/scripts/metrics-exporter.sh'
+```
+
+## エクスポート対象
+
+`metrics.jsonl` の新規行は以下 instrument を持つ 1 OTLP メトリクスバッチに
+変換される:
+
+| Instrument | Type | Unit | ソース field |
+|---|---|---|---|
+| `harness.iter.duration` | histogram | ms | `duration_ms` |
+| `harness.iter.input_tokens` | histogram | {token} | `input_tokens` |
+| `harness.iter.output_tokens` | histogram | {token} | `output_tokens` |
+| `harness.iter.cost` | histogram | {USD} | `cost_usd` |
+| `harness.iter.tool_calls` | histogram | {call} | `tool_calls` |
+| `harness.iter.tool_failures` | histogram | {fail} | `tool_failures` |
+| `harness.rubric.score` | gauge | 1 | `rubric_scores.<axis>`（軸毎 1 gauge） |
+| `harness.iter.cost_cumulative` | counter | {USD} | `cost_usd` の累積和 |
+
+全エミッション共通の resource attributes:
+
+- `service.name = "harness"`
+- `harness.epic = <current_epic>`
+- `harness.sprint = <sprint>`
+- `harness.agent = <agent>`（generator / evaluator / orchestrator）
+- `harness.mode = <interactive|continuous|autonomous-ralph|scheduled>`
+
+## cursor ファイル
+
+exporter は `.harness/.metrics-cursor` に byte offset を保持し、再起動時に
+前回停止点から再開する。起動時:
+
+```bash
+cursor=$(cat .harness/.metrics-cursor 2>/dev/null || echo 0)
+tail -F -c +$((cursor+1)) .harness/metrics.jsonl | while read -r line; do
+  # OTLP へ emit
+  cursor=$(stat -f %z .harness/metrics.jsonl)   # macOS; Linux は -c %s
+  printf '%s' "$cursor" > .harness/.metrics-cursor
+done
+```
+
+cursor ファイル不在時は現 EOF から開始（過去 metrics は既視として扱う）。
+`METRICS_REPLAY=1` で offset 0 から再送可能。
+
+## エンドポイントと認証
+
+サポート:
+
+- OTLP/HTTP JSON（`_config.yml.otlp_endpoint`、例:
+  `https://collector.internal/v1/metrics`）
+- bearer token 認証（`OTLP_AUTH_BEARER` 環境変数）
+- mTLS（`OTLP_CLIENT_CERT` + `OTLP_CLIENT_KEY` 環境変数、任意）
+
+gRPC OTLP は v1 非サポート — shell exporter は依存を軽くするため `curl`
+利用。collector が gRPC のみなら OTLP/HTTP を localhost で受ける sidecar
+translator（OpenTelemetry Collector など）を併用する。
+
+## ヘルスと backpressure
+
+失敗モード:
+
+| 失敗 | 挙動 |
+|---|---|
+| endpoint 5xx / timeout | 指数バックオフ（1s, 4s, 16s）で 3 回まで再試行。最終失敗は `.harness/otlp.log` にログしその行をスキップ。**metrics.jsonl を溜めない** |
+| endpoint 4xx | 再試行なし。payload prefix と行 offset をログしスキップ |
+| 起動時 endpoint 到達不可 | 警告ログを出し exit 0。ユーザ設定修正 |
+| `metrics.jsonl` rotation（truncate） | cursor を 0 に自動リセット |
+
+exporter は **決して** `harness-loop` をブロックしない。メトリクス export は
+ベストエフォート — 1 行 drop でループは止まらない。永続記録は
+`metrics.jsonl` 自体、OTLP は live view。
+
+## 動作確認
+
+```bash
+# 1. 設定確認
+jq -r '.hook_level, .otlp_endpoint' .harness/_config.yml
+
+# 2. 偽 iteration 行を書く
+printf '{"ts":"%s","iter":0,"sprint":1,"agent":"test","duration_ms":100,"cost_usd":0.01,"rubric_scores":{"functionality":0.5},"tool_calls":1,"tool_failures":0}\n' \
+  "$(date -u +%FT%TZ)" >> .harness/metrics.jsonl
+
+# 3. collector で確認
+curl -s "$OTLP_DEBUG_URL" | jq '.resourceMetrics[-1]'
+```
+
+## 無効化
+
+再 init なしで無効化:
+
+```bash
+yq -y '.otlp_endpoint = ""' .harness/_config.yml > /tmp/_config.yml
+mv /tmp/_config.yml .harness/_config.yml
+pkill -f '.harness/scripts/metrics-exporter.sh'
+```
+
+exporter の no-op 経路は tick 毎に `otlp_endpoint` を確認し、クリアされて
+いれば正常終了する。
+
+## 本 reference の非対象
+
+- ログ転送（`progress.md` → logging pipeline）— v1 スコープ外
+- トレースエクスポート（tool 毎 span）— Anthropic SDK は OTLP span を
+  native 出力しない。native サポート追加時に再検討
+- ダッシュボード — 任意の OTLP 互換バックエンド（Grafana Mimir, Honeycomb,
+  Datadog 等）を選択
+- 保持ポリシー — collector / バックエンドに委譲

--- a/skills/harness-loop/references/otlp-exporter.ja.md
+++ b/skills/harness-loop/references/otlp-exporter.ja.md
@@ -15,10 +15,12 @@ REQ-092 を扱う。`.harness/metrics.jsonl` を読んで OpenTelemetry Protocol
 
 ## インストール
 
-`harness-init` は `hook_level == strict` の時
-`.harness/scripts/metrics-exporter.sh` を配置する。スクリプトは
-idempotent ではない: 2 回起動すると cursor ファイルで tail reader が race
-する。常にプロジェクトあたり 1 インスタンスのみ動作させる。
+v1 では `harness-init` は `.harness/scripts/metrics-exporter.sh` を
+出荷しない。strict モード採用時に本ファイル末尾のテンプレートから手動で
+作成する（将来 `/harness-loop --install-metrics-exporter` サブコマンド化
+予定）。スクリプトは idempotent ではない: 2 回起動すると cursor ファイルで
+tail reader が race する。常にプロジェクトあたり 1 インスタンスのみ動作
+させる。
 
 典型的なデプロイパターン:
 

--- a/skills/harness-loop/references/otlp-exporter.md
+++ b/skills/harness-loop/references/otlp-exporter.md
@@ -15,8 +15,10 @@ ships but is a no-op.
 
 ## Install
 
-`harness-init` places `.harness/scripts/metrics-exporter.sh` when
-`hook_level == strict`. The script is idempotent: running it twice
+`.harness/scripts/metrics-exporter.sh` is not shipped by `harness-init`
+in v1. Create it manually from the template at the end of this file
+(or a future `/harness-loop --install-metrics-exporter` subcommand when
+strict mode is in use). The script is not idempotent: running it twice
 starts two tail readers that race on the cursor file. Always ensure
 only one instance runs per project.
 

--- a/skills/harness-loop/references/otlp-exporter.md
+++ b/skills/harness-loop/references/otlp-exporter.md
@@ -1,0 +1,157 @@
+# OTLP Exporter (optional)
+
+Covers REQ-092. An optional side-process reads `.harness/metrics.jsonl`
+and forwards per-iteration metrics to an OpenTelemetry Protocol (OTLP)
+endpoint so cost, rubric trends, and tool-failure rates can be viewed
+alongside other project telemetry.
+
+Active only when **both** conditions hold:
+
+- `_config.yml.hook_level == "strict"`
+- `_config.yml.otlp_endpoint` is a non-empty URL
+
+Otherwise this reference is informational — the exporter script still
+ships but is a no-op.
+
+## Install
+
+`harness-init` places `.harness/scripts/metrics-exporter.sh` when
+`hook_level == strict`. The script is idempotent: running it twice
+starts two tail readers that race on the cursor file. Always ensure
+only one instance runs per project.
+
+Typical deployment patterns:
+
+- **Session scope** — start alongside `harness-loop`, stop when the
+  session ends. Suitable for interactive / continuous modes.
+- **Long-running** — run under `launchd` (macOS) or `systemd --user`
+  (Linux), survives sessions. Suitable for `autonomous-ralph` and
+  `scheduled` modes.
+
+## Invocation
+
+Foreground (for debugging):
+
+```bash
+.harness/scripts/metrics-exporter.sh
+```
+
+Detached (for overnight):
+
+```bash
+nohup .harness/scripts/metrics-exporter.sh >> .harness/otlp.log 2>&1 &
+disown
+```
+
+Stop:
+
+```bash
+pkill -f '.harness/scripts/metrics-exporter.sh'
+```
+
+## What it exports
+
+Every new line in `metrics.jsonl` is transformed into one OTLP metric
+batch with the following instruments:
+
+| Instrument | Type | Unit | Source field |
+|---|---|---|---|
+| `harness.iter.duration` | histogram | ms | `duration_ms` |
+| `harness.iter.input_tokens` | histogram | {token} | `input_tokens` |
+| `harness.iter.output_tokens` | histogram | {token} | `output_tokens` |
+| `harness.iter.cost` | histogram | {USD} | `cost_usd` |
+| `harness.iter.tool_calls` | histogram | {call} | `tool_calls` |
+| `harness.iter.tool_failures` | histogram | {fail} | `tool_failures` |
+| `harness.rubric.score` | gauge | 1 | `rubric_scores.<axis>` (one gauge per axis) |
+| `harness.iter.cost_cumulative` | counter | {USD} | running sum of `cost_usd` |
+
+Common resource attributes on every emission:
+
+- `service.name = "harness"`
+- `harness.epic = <current_epic>`
+- `harness.sprint = <sprint>`
+- `harness.agent = <agent>` (generator / evaluator / orchestrator)
+- `harness.mode = <interactive|continuous|autonomous-ralph|scheduled>`
+
+## Cursor file
+
+The exporter keeps a byte offset at `.harness/.metrics-cursor` so a
+restart resumes where the previous run stopped. On startup:
+
+```bash
+cursor=$(cat .harness/.metrics-cursor 2>/dev/null || echo 0)
+tail -F -c +$((cursor+1)) .harness/metrics.jsonl | while read -r line; do
+  # emit to OTLP
+  cursor=$(stat -f %z .harness/metrics.jsonl)   # macOS; -c %s on Linux
+  printf '%s' "$cursor" > .harness/.metrics-cursor
+done
+```
+
+If the cursor file is missing, the exporter starts from the current
+end-of-file (treat historical metrics as already seen). Override with
+`METRICS_REPLAY=1` to start from offset 0.
+
+## Endpoint and auth
+
+Supported endpoints:
+
+- OTLP/HTTP JSON on `_config.yml.otlp_endpoint` (e.g.,
+  `https://collector.internal/v1/metrics`)
+- OTLP/HTTP with bearer token via `OTLP_AUTH_BEARER` env var
+- mTLS via `OTLP_CLIENT_CERT` + `OTLP_CLIENT_KEY` env vars (optional)
+
+gRPC OTLP is not supported in v1 — the shell exporter uses `curl` to
+keep dependencies light. If your collector only speaks gRPC, run a
+sidecar translator (e.g., an OpenTelemetry Collector) that accepts
+OTLP/HTTP on localhost.
+
+## Health and backpressure
+
+Failure modes:
+
+| Failure | Behaviour |
+|---|---|
+| Endpoint 5xx / timeout | Retry up to 3 times with exponential backoff (1s, 4s, 16s). On final failure, log to `.harness/otlp.log` and continue past that line — **do not back up metrics.jsonl** |
+| Endpoint 4xx | Do not retry; log payload prefix and line offset; skip |
+| Endpoint unreachable at start | Exit 0 with a warning; user addresses config |
+| `metrics.jsonl` rotated (truncated) | Reset cursor to 0 automatically |
+
+The exporter **never** blocks `harness-loop`. Metrics export is
+best-effort — a dropped line does not stop the loop. `metrics.jsonl`
+itself is the durable record; OTLP is the live view.
+
+## Sanity check
+
+```bash
+# 1. Confirm config
+jq -r '.hook_level, .otlp_endpoint' .harness/_config.yml
+
+# 2. Write a fake iteration line
+printf '{"ts":"%s","iter":0,"sprint":1,"agent":"test","duration_ms":100,"cost_usd":0.01,"rubric_scores":{"functionality":0.5},"tool_calls":1,"tool_failures":0}\n' \
+  "$(date -u +%FT%TZ)" >> .harness/metrics.jsonl
+
+# 3. Check the collector
+curl -s "$OTLP_DEBUG_URL" | jq '.resourceMetrics[-1]'
+```
+
+## Disabling
+
+To disable without reinitialising:
+
+```bash
+yq -y '.otlp_endpoint = ""' .harness/_config.yml > /tmp/_config.yml
+mv /tmp/_config.yml .harness/_config.yml
+pkill -f '.harness/scripts/metrics-exporter.sh'
+```
+
+The no-op path in the exporter checks `otlp_endpoint` on each tick and
+exits cleanly when cleared.
+
+## What this does NOT cover
+
+- Log forwarding (`progress.md` → logging pipeline) — out of scope v1
+- Trace export (per-tool spans) — the Anthropic SDK does not emit OTLP
+  spans natively; revisit if it gains native support
+- Dashboarding — pick any OTLP-compatible backend (Grafana Mimir,
+  Honeycomb, Datadog, etc.)
+- Retention policy — delegated to the collector / backend

--- a/skills/harness-loop/references/pr-creation-guide.ja.md
+++ b/skills/harness-loop/references/pr-creation-guide.ja.md
@@ -1,0 +1,256 @@
+# PR 作成ガイド
+
+REQ-033 を扱う。sprint が pass すると `harness-loop` は pull request を
+開く。PR 本文は実装内容と Evaluator の承認理由を定型化した要約。split と
+bundled は同一テンプレートをヘッダ差分のみで使い分ける。
+
+## 事前条件
+
+PR 作成前に確認:
+
+1. `contract.status == "done"`（最終 iteration で全 rubric 軸が threshold 以上）
+2. `_state.json.aborted_reason == null`
+3. sprint ブランチがローカルに存在し、親ブランチより 1 commit 以上進んでいる
+4. `_config.yml.tracker == "github"`（本ガイドは GitHub のみ。gitlab と
+   none は末尾で扱う）
+
+どれか満たさない場合は PR 作成せず、理由を `shared_state.md/Decisions` と
+`progress.md` に記録し、SKILL flow の Step 9（Sprint Transition）へ戻る。
+
+## ブランチモデル
+
+```
+main（または _config.yml.default_branch）
+ └── harness/<epic>                 ← epic ブランチ（任意、後述）
+      ├── harness/<epic>/sprint-1-<feature>    ← split sprint PR ブランチ
+      └── harness/<epic>/sprint-2-<bundle>     ← bundled sprint PR ブランチ
+```
+
+有効な 2 形態:
+
+- **Flat**: 各 sprint を `main` から直接分岐。PR 宛先は `main`。
+  シンプル。4 sprint 未満の epic 推奨。
+- **Epic stacking**: `main` から epic ブランチを 1 本、sprint ブランチは
+  epic ブランチから分岐、PR 宛先も epic ブランチ。epic は最後にまとめて
+  merge。大きな epic でレビュー文脈を確保したい場合に適する。
+  `_config.yml.pr_stack == true` が必要。
+
+epic 開始時にどちらかを選び `_state.json.pr_model` に記録する。epic 内で
+混ぜない。
+
+## Split PR（1 sprint = 1 feature = 1 PR）
+
+### `gh pr create` 呼び出し
+
+```bash
+gh pr create \
+  --base "<base-branch>" \
+  --head "harness/<epic>/sprint-<n>-<feature>" \
+  --title "feat(<feature>): sprint-<n> — <goal-short>" \
+  --body-file /tmp/pr-body-sprint-<n>.md \
+  --assignee @me
+```
+
+`<base-branch>` は `_config.yml.default_branch`（flat）または
+`harness/<epic>`（stacking）。`--draft` は**使わない** — Evaluator の
+承認済みなので。
+
+### タイトル書式
+
+`feat(<feature>): sprint-<n> — <goal-short>`
+
+- `<goal-short>`: `contract.goal` の先頭節。55 字で切り詰め
+- 非コード成果物（docs, config 等）は `chore(<feature>)` / `docs(<feature>)`
+  を使う（最終 iteration の feedback に `change_type` を Generator が記録）
+
+### 本文テンプレート
+
+```markdown
+## Summary
+
+<contract.goal をそのまま>
+
+## Acceptance Scenarios
+
+<!-- contract.md から転記。Evaluator が全項目の pass を確認済 -->
+
+- **AS-1**: <given / when / then 1 行> — ✅ pass (iter=<n>)
+- **AS-2**: <given / when / then 1 行> — ✅ pass (iter=<n>)
+...
+
+## Rubric Verdict (final iteration iter=<n>)
+
+| Axis | Score | Threshold | Verdict |
+|---|---|---|---|
+| Functionality | 1.00 | 1.0 | ✅ |
+| Craft | 0.85 | 0.7 | ✅ |
+| Design | 0.80 | 0.7 | ✅ |
+| Originality | 0.60 | 0.5 | ✅ |
+
+Evaluator 詳細: `sprints/sprint-<n>-<feature>/feedback/evaluator-<n>.md`
+
+Evidence: `sprints/sprint-<n>-<feature>/evidence/`
+
+## Iteration Count
+
+<n> / <max_iterations>. 経過時間 <HH:MM>. コスト <$X.XX>（この sprint）。
+
+## Closes
+
+Closes #<sprint-issue-number>
+
+<!-- 任意: stacking 時に epic Issue を参照 -->
+<!-- Part of #<epic-issue-number>. -->
+```
+
+### Issue リンク
+
+- **split**: `Closes #<n>` 行を 1 本（sprint Issue）。
+  `_state.json.epic_issue` が非 null なら `Part of #<epic>` を別行で追加
+  （**`Closes` ではない**。epic は最終 sprint merge 時に閉じる）
+- `_state.json.sprint_issues[<n>]` に Issue 番号/URL が保持される。
+  番号を抽出（`gh` が当該リポジトリ内で解決）
+
+## Bundled PR（1 sprint = 複数 feature = 1 PR）
+
+### ブランチとタイトル
+
+```bash
+BRANCH="harness/<epic>/sprint-<n>-bundle-<feat1>-<feat2>"
+git switch -c "$BRANCH"
+# ...commits...
+gh pr create \
+  --base "<base-branch>" \
+  --head "$BRANCH" \
+  --title "feat(<epic>): sprint-<n> — <feat1> + <feat2>" \
+  --body-file /tmp/pr-body-sprint-<n>.md
+```
+
+タイトルは主要 feature を `+` 区切りで列挙。3 を超える場合は
+`feat(<epic>): sprint-<n> — <feat1> + <feat2> + N others` 形式。
+
+### 本文テンプレート（split と差分あり）
+
+```markdown
+## Summary
+
+<contract.goal をそのまま — これら feature をまとめて出す理由を記載>
+
+## Bundled features
+
+- **<feat1>**: <1 行 goal>
+- **<feat2>**: <1 行 goal>
+...
+
+## Acceptance Scenarios
+
+<!-- feature 毎にグルーピング。Evaluator 全項目確認済 -->
+
+### <feat1>
+- **AS-1**: ... — ✅ pass
+...
+
+### <feat2>
+- **AS-1**: ... — ✅ pass
+...
+
+## Rubric Verdict (final iteration iter=<n>)
+
+| Axis | Score | Threshold | Verdict |
+|---|---|---|---|
+| Functionality | 1.00 | 1.0 | ✅ |
+...
+
+Evaluator 詳細: `sprints/sprint-<n>-<bundle>/feedback/evaluator-<n>.md`
+
+## Iteration Count
+
+<n> / <max_iterations>. 経過時間 <HH:MM>. コスト <$X.XX>（この sprint）。
+
+## Closes
+
+Closes #<feat1-issue>
+Closes #<feat2-issue>
+<!-- bundled sprint Issue 毎に 1 行 -->
+```
+
+### 複数 Closes
+
+bundle 内各 feature には `harness-plan` が sprint Issue を作成済
+（`issue-create.md` 参照）。feature 毎に `Closes #N` を出力 — PR merge 時に
+GitHub が各 Issue を close。
+
+bundle が `roadmap.md` で定義されているが sprint Issue が作られていない
+（plan 時に tracker が `none` で後から切替など）場合は、`Closes` 行を出さず
+サマリリストのみとし、`shared_state.md/Decisions` に不整合を記録する。
+
+## Reviewers / Labels / Milestones
+
+v1 はシンプルに:
+
+- **Reviewers**: デフォルト無し。レビュー経路を望むユーザは
+  `_config.yml.pr_reviewers: [user1, user2]` を設定、harness-loop が
+  `--reviewer user1 --reviewer user2` を追加
+- **Labels**: 常に `harness-loop` を付与。sprint の `roadmap.md` に
+  `labels:` があれば pass-through
+- **Milestone**: `_state.json.epic_issue` があり、その milestone が
+  非 null なら継承。無ければ省略
+
+## `gh pr create` 成功後
+
+成功時 `gh` は PR URL を stdout に出す。Orchestrator は:
+
+1. stdout から URL を抽出
+2. `_state.json.sprint_issues[<n>].pr` に保存
+3. `shared_state.md/Decisions` に 1 行追記:
+   ```
+   [<ts>] PR opened: sprint-<n> <pr-url> (bundling=<split|bundled>)
+   ```
+4. `progress.md` に 1 行追記:
+   ```
+   [<ts>] decision: sprint-<n> PR opened <pr-url>
+   ```
+5. `_state.json` の更新を commit（PR 自体は GitHub 側の所有）
+
+`gh pr create` が失敗した場合（auth / network / branch-未 push）、エラーを
+ログして 1 回リトライ。2 回目失敗時は `pending_human=true`、
+`aborted_reason: "pr-create-failed: <gh stderr>"` にして halt。
+
+## 非 GitHub tracker
+
+### `tracker: gitlab`
+
+v1 は `glab` を呼び出さない。代わりに sprint pass 後:
+
+1. 同テンプレートで本文を構築
+2. `.harness/<epic>/sprints/sprint-<n>-*/pr-body.md` に書き出す
+3. `.harness/<epic>/pending-prs.md`（epic レベル台帳）に追記:
+   ```
+   - sprint-<n>: branch=<branch> body=sprints/sprint-<n>-*/pr-body.md
+   ```
+4. ユーザ向け表示: "pending-prs.md 台帳から手動で MR を開いてください"
+5. `_state.json.sprint_issues[<n>].pr = "gitlab:pending"` に設定
+
+### `tracker: none`
+
+PR 作成をスキップ。sprint 完了は git 履歴（iter 毎 commit）と
+`shared_state.md` に残る。`progress.md` に追記:
+
+```
+[<ts>] decision: sprint-<n> completed (tracker=none, no PR)
+```
+
+## Dry-run
+
+`harness-loop --dry-run-pr` は
+`.harness/<epic>/sprints/sprint-<n>-*/pr-body.preview.md` に本文を書き出し、
+`gh pr create` コマンドを実行せず表示する。初 sprint でテンプレートをまだ
+信頼しきれていないユーザ向け。
+
+## 本ガイドの非対象
+
+- PR レビューコメント対応 — 人間の活動。merged-PR のレビュー知見からの
+  ルール更新は将来 `/harness-rules-update` で提案する可能性あり
+- レビュー後の force-push — harness-loop スコープ外
+- Auto-merge — v1 スコープ外。明示的な人間 merge のみ
+- リリース tagging — harness パイプライン範囲外

--- a/skills/harness-loop/references/pr-creation-guide.ja.md
+++ b/skills/harness-loop/references/pr-creation-guide.ja.md
@@ -20,23 +20,23 @@ PR 作成前に確認:
 ## ブランチモデル
 
 ```
-main（または _config.yml.default_branch）
+<default-branch>
  └── harness/<epic>                 ← epic ブランチ（任意、後述）
       ├── harness/<epic>/sprint-1-<feature>    ← split sprint PR ブランチ
       └── harness/<epic>/sprint-2-<bundle>     ← bundled sprint PR ブランチ
 ```
 
-有効な 2 形態:
+`<default-branch>` は実行時解決:
+`git symbolic-ref refs/remotes/origin/HEAD`（例: `origin/main`）→
+`git config --get init.defaultBranch` → 文字列 `main` の順で探索する。
+invocation 単位で上書きしたい場合は `--base <branch>` を渡す。
 
-- **Flat**: 各 sprint を `main` から直接分岐。PR 宛先は `main`。
-  シンプル。4 sprint 未満の epic 推奨。
-- **Epic stacking**: `main` から epic ブランチを 1 本、sprint ブランチは
-  epic ブランチから分岐、PR 宛先も epic ブランチ。epic は最後にまとめて
-  merge。大きな epic でレビュー文脈を確保したい場合に適する。
-  `_config.yml.pr_stack == true` が必要。
-
-epic 開始時にどちらかを選び `_state.json.pr_model` に記録する。epic 内で
-混ぜない。
+v1 は **flat** 形態のみ: 各 sprint を解決済みのデフォルトブランチから
+直接分岐し、PR 宛先も同ブランチとする。Epic stacking（epic ブランチを
+デフォルトから 1 本、sprint ブランチは epic ブランチから分岐、epic を
+最後にまとめて merge）は opt-in。epic 初回 sprint に `--pr-stack` を
+渡せば採用され、以降は `_state.json.pr_model`（`flat` または `stack`）
+に保持される。epic 内で混ぜない。
 
 ## Split PR（1 sprint = 1 feature = 1 PR）
 
@@ -51,7 +51,7 @@ gh pr create \
   --assignee @me
 ```
 
-`<base-branch>` は `_config.yml.default_branch`（flat）または
+`<base-branch>` は解決済みデフォルトブランチ（flat）または
 `harness/<epic>`（stacking）。`--draft` は**使わない** — Evaluator の
 承認済みなので。
 
@@ -189,8 +189,10 @@ bundle が `roadmap.md` で定義されているが sprint Issue が作られて
 v1 はシンプルに:
 
 - **Reviewers**: デフォルト無し。レビュー経路を望むユーザは
-  `_config.yml.pr_reviewers: [user1, user2]` を設定、harness-loop が
-  `--reviewer user1 --reviewer user2` を追加
+  `/harness-loop` 呼び出し時に `--reviewer <login>` を渡すか、
+  リポジトリレベルのデフォルトレビュアーを `gh` CLI 側で設定する
+  （例: shell alias 経由で `gh pr create ... --reviewer` に伝える）。
+  harness-loop は v1 ではこの用途で `_config.yml` を参照しない
 - **Labels**: 常に `harness-loop` を付与。sprint の `roadmap.md` に
   `labels:` があれば pass-through
 - **Milestone**: `_state.json.epic_issue` があり、その milestone が
@@ -201,7 +203,9 @@ v1 はシンプルに:
 成功時 `gh` は PR URL を stdout に出す。Orchestrator は:
 
 1. stdout から URL を抽出
-2. `_state.json.sprint_issues[<n>].pr` に保存
+2. `_state.json.sprint_prs[<n>]` に保存（harness-loop が追加する
+   additive キー。harness-plan が書いた Issue URL の
+   `sprint_issues[<n>]` は不変）
 3. `shared_state.md/Decisions` に 1 行追記:
    ```
    [<ts>] PR opened: sprint-<n> <pr-url> (bundling=<split|bundled>)
@@ -229,7 +233,7 @@ v1 は `glab` を呼び出さない。代わりに sprint pass 後:
    - sprint-<n>: branch=<branch> body=sprints/sprint-<n>-*/pr-body.md
    ```
 4. ユーザ向け表示: "pending-prs.md 台帳から手動で MR を開いてください"
-5. `_state.json.sprint_issues[<n>].pr = "gitlab:pending"` に設定
+5. `_state.json.sprint_prs[<n>] = "gitlab:pending"` に設定
 
 ### `tracker: none`
 

--- a/skills/harness-loop/references/pr-creation-guide.md
+++ b/skills/harness-loop/references/pr-creation-guide.md
@@ -1,0 +1,266 @@
+# PR Creation Guide
+
+Covers REQ-033. On sprint pass, `harness-loop` opens a pull request
+whose body is a standardised summary of what shipped and why the
+Evaluator accepted it. Split and bundled sprints use the same
+template with minor header differences.
+
+## Pre-conditions
+
+Before PR creation, verify:
+
+1. `contract.status == "done"` (all rubric axes ≥ threshold on the
+   final iteration)
+2. `_state.json.aborted_reason == null`
+3. The sprint branch exists locally and is ahead of the parent branch
+   by at least one commit
+4. `_config.yml.tracker == "github"` (this guide only covers GitHub;
+   gitlab and none cases are covered at the end)
+
+If any pre-condition fails, do not open a PR. Log the reason to
+`shared_state.md/Decisions` and `progress.md`, then return to Step 9
+(Sprint Transition) of the SKILL flow.
+
+## Branch model
+
+```
+main (or _config.yml.default_branch)
+ └── harness/<epic>                 ← epic branch (optional; see below)
+      ├── harness/<epic>/sprint-1-<feature>    ← split sprint PR branch
+      └── harness/<epic>/sprint-2-<bundle>     ← bundled sprint PR branch
+```
+
+Two valid shapes:
+
+- **Flat**: each sprint branches directly off `main`. PR target is
+  `main`. Simplest; recommended for < 4 sprint epics.
+- **Epic stacking**: one epic branch off `main`, sprint branches off
+  epic branch, PRs target the epic branch, and the epic is merged
+  last. Better for reviewer context in large epics. Requires
+  `_config.yml.pr_stack == true`.
+
+Pick one at epic start and record in `_state.json.pr_model`. Do not
+mix within an epic.
+
+## Split PR (one sprint = one feature = one PR)
+
+### `gh pr create` invocation
+
+```bash
+gh pr create \
+  --base "<base-branch>" \
+  --head "harness/<epic>/sprint-<n>-<feature>" \
+  --title "feat(<feature>): sprint-<n> — <goal-short>" \
+  --body-file /tmp/pr-body-sprint-<n>.md \
+  --assignee @me
+```
+
+`<base-branch>` is `_config.yml.default_branch` (flat) or
+`harness/<epic>` (stacking). Do **not** use `--draft` — the Evaluator
+has already signed off.
+
+### Title format
+
+`feat(<feature>): sprint-<n> — <goal-short>`
+
+- `<goal-short>`: first clause of `contract.goal`, truncated to 55 chars
+- If non-code deliverable (docs, config, etc.), use `chore(<feature>)`
+  or `docs(<feature>)` as appropriate (the Generator records
+  `change_type` in the final iteration's feedback file)
+
+### Body template
+
+```markdown
+## Summary
+
+<contract.goal verbatim>
+
+## Acceptance Scenarios
+
+<!-- Copied from contract.md; Evaluator confirmed each passes -->
+
+- **AS-1**: <given / when / then one-liner> — ✅ pass (iter=<n>)
+- **AS-2**: <given / when / then one-liner> — ✅ pass (iter=<n>)
+...
+
+## Rubric Verdict (final iteration iter=<n>)
+
+| Axis | Score | Threshold | Verdict |
+|---|---|---|---|
+| Functionality | 1.00 | 1.0 | ✅ |
+| Craft | 0.85 | 0.7 | ✅ |
+| Design | 0.80 | 0.7 | ✅ |
+| Originality | 0.60 | 0.5 | ✅ |
+
+Full Evaluator notes: `sprints/sprint-<n>-<feature>/feedback/evaluator-<n>.md`
+
+Evidence: `sprints/sprint-<n>-<feature>/evidence/`
+
+## Iteration Count
+
+<n> / <max_iterations>. Total elapsed <HH:MM>. Cost <$X.XX> (this sprint).
+
+## Closes
+
+Closes #<sprint-issue-number>
+
+<!-- Optional: references the epic Issue when stacking. -->
+<!-- Part of #<epic-issue-number>. -->
+```
+
+### Issue linkage
+
+- **split**: exactly one `Closes #<n>` line (the sprint Issue). If
+  `_state.json.epic_issue` is non-null, add a separate
+  `Part of #<epic>` line — **not** `Closes`, because the epic closes
+  only when the final sprint merges.
+- `_state.json.sprint_issues[<n>]` holds the Issue number or URL.
+  Extract the number; `gh` resolves it within the current repo.
+
+## Bundled PR (one sprint = multiple features = one PR)
+
+### Branch and title
+
+```bash
+BRANCH="harness/<epic>/sprint-<n>-bundle-<feat1>-<feat2>"
+git switch -c "$BRANCH"
+# ...commits...
+gh pr create \
+  --base "<base-branch>" \
+  --head "$BRANCH" \
+  --title "feat(<epic>): sprint-<n> — <feat1> + <feat2>" \
+  --body-file /tmp/pr-body-sprint-<n>.md
+```
+
+Title lists the primary features separated by `+`. If more than three,
+use `feat(<epic>): sprint-<n> — <feat1> + <feat2> + N others`.
+
+### Body template (differs from split)
+
+```markdown
+## Summary
+
+<contract.goal verbatim — explains why these features ship together>
+
+## Bundled features
+
+- **<feat1>**: <one-line goal>
+- **<feat2>**: <one-line goal>
+...
+
+## Acceptance Scenarios
+
+<!-- Grouped by feature; all confirmed by Evaluator -->
+
+### <feat1>
+- **AS-1**: ... — ✅ pass
+...
+
+### <feat2>
+- **AS-1**: ... — ✅ pass
+...
+
+## Rubric Verdict (final iteration iter=<n>)
+
+| Axis | Score | Threshold | Verdict |
+|---|---|---|---|
+| Functionality | 1.00 | 1.0 | ✅ |
+...
+
+Full Evaluator notes: `sprints/sprint-<n>-<bundle>/feedback/evaluator-<n>.md`
+
+## Iteration Count
+
+<n> / <max_iterations>. Total elapsed <HH:MM>. Cost <$X.XX> (this sprint).
+
+## Closes
+
+Closes #<feat1-issue>
+Closes #<feat2-issue>
+<!-- One Closes line per bundled sprint Issue. -->
+```
+
+### Multiple Closes
+
+Every feature in the bundle had a sprint Issue created by
+`harness-plan` (see `issue-create.md`). Emit one `Closes #N` per
+feature — GitHub closes each Issue when the PR merges.
+
+If the bundle was defined by `roadmap.md` but sprint Issues were not
+created (e.g., tracker was `none` at plan time but later switched),
+emit only a summary list without `Closes` lines and note the
+discrepancy in `shared_state.md/Decisions`.
+
+## Reviewers, labels, milestones
+
+v1 keeps these simple:
+
+- **Reviewers**: none by default. Users who want a review path set
+  `_config.yml.pr_reviewers: [user1, user2]` and `harness-loop` adds
+  `--reviewer user1 --reviewer user2`.
+- **Labels**: add `harness-loop` always. If the feature's sprint in
+  `roadmap.md` carries `labels:`, pass them through.
+- **Milestone**: if `_state.json.epic_issue` exists and its milestone
+  is non-null, inherit. Otherwise omit.
+
+## After `gh pr create`
+
+On success, `gh` prints the PR URL. The Orchestrator:
+
+1. Parses the URL from stdout
+2. Stores it at `_state.json.sprint_issues[<n>].pr`
+3. Appends a line to `shared_state.md/Decisions`:
+   ```
+   [<ts>] PR opened: sprint-<n> <pr-url> (bundling=<split|bundled>)
+   ```
+4. Appends a line to `progress.md`:
+   ```
+   [<ts>] decision: sprint-<n> PR opened <pr-url>
+   ```
+5. Commits the `_state.json` update (not the PR itself — GitHub owns
+   that side)
+
+On `gh pr create` failure (auth, network, branch-not-pushed), log the
+error and retry once. Second failure sets `pending_human=true` with
+`aborted_reason: "pr-create-failed: <gh stderr>"` and halts.
+
+## Non-GitHub trackers
+
+### `tracker: gitlab`
+
+v1 does not shell out to `glab`. Instead, after the sprint passes:
+
+1. Build the same body template
+2. Write it to `.harness/<epic>/sprints/sprint-<n>-*/pr-body.md`
+3. Append to `.harness/<epic>/pending-prs.md` (epic-level ledger):
+   ```
+   - sprint-<n>: branch=<branch> body=sprints/sprint-<n>-*/pr-body.md
+   ```
+4. Print to user: "Open MR manually using the pending-prs.md ledger"
+5. Set `_state.json.sprint_issues[<n>].pr = "gitlab:pending"`
+
+### `tracker: none`
+
+Skip PR creation entirely. Sprint completion is recorded in git
+history (the per-iter commits) and `shared_state.md`. Append to
+`progress.md`:
+
+```
+[<ts>] decision: sprint-<n> completed (tracker=none, no PR)
+```
+
+## Dry-run
+
+`harness-loop --dry-run-pr` builds the body at
+`.harness/<epic>/sprints/sprint-<n>-*/pr-body.preview.md` and prints
+the `gh pr create` command without executing it. Useful for first
+sprints when the user is still trusting the template.
+
+## What this guide does NOT cover
+
+- PR review comments and iteration after feedback — that is a human
+  activity; `/harness-rules-update` may eventually propose rule
+  changes from merged-PR review findings
+- Force-pushing after mid-review changes — out of harness-loop scope
+- Auto-merge — out of scope for v1; explicit human merge only
+- Release tagging — outside the harness pipeline

--- a/skills/harness-loop/references/pr-creation-guide.md
+++ b/skills/harness-loop/references/pr-creation-guide.md
@@ -24,23 +24,23 @@ If any pre-condition fails, do not open a PR. Log the reason to
 ## Branch model
 
 ```
-main (or _config.yml.default_branch)
+<default-branch>
  └── harness/<epic>                 ← epic branch (optional; see below)
       ├── harness/<epic>/sprint-1-<feature>    ← split sprint PR branch
       └── harness/<epic>/sprint-2-<bundle>     ← bundled sprint PR branch
 ```
 
-Two valid shapes:
+`<default-branch>` is resolved at runtime — first by
+`git symbolic-ref refs/remotes/origin/HEAD` (e.g., `origin/main`), then
+by `git config --get init.defaultBranch`, then by the literal `main`.
+The user can override for a single invocation with `--base <branch>`.
 
-- **Flat**: each sprint branches directly off `main`. PR target is
-  `main`. Simplest; recommended for < 4 sprint epics.
-- **Epic stacking**: one epic branch off `main`, sprint branches off
-  epic branch, PRs target the epic branch, and the epic is merged
-  last. Better for reviewer context in large epics. Requires
-  `_config.yml.pr_stack == true`.
-
-Pick one at epic start and record in `_state.json.pr_model`. Do not
-mix within an epic.
+v1 uses the **flat** shape only: each sprint branches directly off the
+resolved default branch; PR target is that same branch. Epic stacking
+(one epic branch off default, sprint branches off the epic branch,
+epic merged last) is opt-in with `--pr-stack` on the first sprint of
+an epic; the choice persists in `_state.json.pr_model` (`flat` or
+`stack`). Do not mix within an epic.
 
 ## Split PR (one sprint = one feature = one PR)
 
@@ -55,7 +55,7 @@ gh pr create \
   --assignee @me
 ```
 
-`<base-branch>` is `_config.yml.default_branch` (flat) or
+`<base-branch>` is the resolved default branch (flat) or
 `harness/<epic>` (stacking). Do **not** use `--draft` — the Evaluator
 has already signed off.
 
@@ -195,9 +195,11 @@ discrepancy in `shared_state.md/Decisions`.
 
 v1 keeps these simple:
 
-- **Reviewers**: none by default. Users who want a review path set
-  `_config.yml.pr_reviewers: [user1, user2]` and `harness-loop` adds
-  `--reviewer user1 --reviewer user2`.
+- **Reviewers**: none by default. Users who want a review path pass
+  `--reviewer <login>` when invoking `/harness-loop`, or set the
+  repository-level default reviewer via `gh` (e.g.,
+  `gh pr create ... --reviewer` via a shell alias). harness-loop does
+  not read `_config.yml` for this in v1.
 - **Labels**: add `harness-loop` always. If the feature's sprint in
   `roadmap.md` carries `labels:`, pass them through.
 - **Milestone**: if `_state.json.epic_issue` exists and its milestone
@@ -208,7 +210,9 @@ v1 keeps these simple:
 On success, `gh` prints the PR URL. The Orchestrator:
 
 1. Parses the URL from stdout
-2. Stores it at `_state.json.sprint_issues[<n>].pr`
+2. Stores it at `_state.json.sprint_prs[<n>]` (an additive key owned
+   by harness-loop; `sprint_issues[<n>]` remains the
+   harness-plan-written Issue URL string and is untouched)
 3. Appends a line to `shared_state.md/Decisions`:
    ```
    [<ts>] PR opened: sprint-<n> <pr-url> (bundling=<split|bundled>)
@@ -237,7 +241,7 @@ v1 does not shell out to `glab`. Instead, after the sprint passes:
    - sprint-<n>: branch=<branch> body=sprints/sprint-<n>-*/pr-body.md
    ```
 4. Print to user: "Open MR manually using the pending-prs.md ledger"
-5. Set `_state.json.sprint_issues[<n>].pr = "gitlab:pending"`
+5. Set `_state.json.sprint_prs[<n>] = "gitlab:pending"`
 
 ### `tracker: none`
 

--- a/skills/harness-loop/references/shared-state-protocol.ja.md
+++ b/skills/harness-loop/references/shared-state-protocol.ja.md
@@ -1,0 +1,163 @@
+# Shared-read / Isolated-write プロトコル
+
+REQ-030 と REQ-074 を扱う。sprint 中、Planner / Generator / Evaluator と
+Orchestrator は同一の `shared_state.md` 台帳を全員が読むが、**書き込みは
+Orchestrator のみ**。他のエージェントは各自の `feedback/{role}-{iter}.md`
+に append する。これにより台帳は race なく、iteration 毎の監査可能性を
+保つ。
+
+## ファイル配置（sprint 単位）
+
+```
+.harness/<epic>/sprints/sprint-<n>-<feature>/
+├── contract.md                     ← 交渉後に凍結（Orchestrator 書込、全員読取）
+├── shared_state.md                 ← Orchestrator のみ書込、全員読取
+├── feedback/
+│   ├── planner-ruling.md           ← Planner のみ書込（交渉停滞時）
+│   ├── planner-<iter>.md           ← Planner のみ書込（稀：再計画要求）
+│   ├── generator-<round>.md        ← Generator のみ書込（交渉ラウンド）
+│   ├── generator-<iter>.md         ← Generator のみ書込（実装 iteration）
+│   ├── evaluator-<round>.md        ← Evaluator のみ書込（交渉ラウンド）
+│   └── evaluator-<iter>.md         ← Evaluator のみ書込（実装 iteration）
+└── evidence/                       ← Evaluator が実行成果物、全員読取
+```
+
+交渉ラウンドは `<round>`（1..3）で、実装 iteration は `<iter>`
+（1..max_iterations）でキー付け。ファイル名上の番号空間は重ならない。
+書込時の `contract.status` で区別：`negotiating` → `round`、
+`active` → `iter`。
+
+harness-loop 内での実装：両シリーズを同一ディレクトリに置き、番号レンジを
+分けて保持。Orchestrator は読取時に `contract.status` から round か iter
+を判別する。
+
+## 書き込み権限（正式）
+
+| パス | Orchestrator | Planner | Generator | Evaluator |
+|---|---|---|---|---|
+| `contract.md` frontmatter | ✅ freeze のみ | ❌ | ❌ | ❌ |
+| `contract.md` Negotiation Log | ✅ feedback から転記 | ❌ | ❌ | ❌ |
+| `shared_state.md` | ✅ 唯一の書き手 | ❌ | ❌ | ❌ |
+| `feedback/planner-*.md` | ❌ | ✅ | ❌ | ❌ |
+| `feedback/generator-*.md` | ❌ | ❌ | ✅ | ❌ |
+| `feedback/evaluator-*.md` | ❌ | ❌ | ❌ | ✅ |
+| `evidence/*` | ❌ | ❌ | ❌ | ✅ |
+| `_state.json` | ✅ 唯一の書き手 | ❌ | ❌ | ❌ |
+| `metrics.jsonl` | ✅ 唯一の書き手 | ❌ | ❌ | ❌ |
+| `progress.md` | ✅ 直接 append | PostToolUse hook 経由 | PostToolUse hook 経由 | PostToolUse hook 経由 |
+
+`progress.md` はエージェント側の書き込みが
+`.harness/scripts/progress-append.sh` hook 経由で到達する共有ログ。直接の
+ファイル操作ではない。hook 経路は race-safe（POSIX 上の小さな `>>` 追記は
+atomic）。
+
+## `shared_state.md` セクション所有権
+
+テンプレートのコメントで所有権は明示済み。要約:
+
+| セクション | 記入タイミング | Orchestrator のアクション |
+|---|---|---|
+| `## Plan` | sprint 開始時 | contract.md の `goal` と `acceptance_scenarios` を転記 |
+| `## Contract` | contract 凍結時 | `sprint-<n>-contract.md @ <SHA>` を記録 |
+| `## Negotiation` | 各ラウンド後 | ラウンド毎に 2 行（G+E）、停滞時は ruling 行 |
+| `## WorkLog` | 各 Generator turn 後 | 1 行: iter, agent, commit, 要約ポインタ |
+| `## Evaluation` | 各 Evaluator turn 後 | 1 行: iter, verdict, 軸毎スコア, evidence ポインタ |
+| `## Decisions` | 状態遷移時 | 1 行: decision 種別, 理由, commit SHA |
+
+append は常に新規行。in-place 編集は禁止。正準的な append 実装:
+
+```bash
+# 擬似コード; 実 Orchestrator 経路は jq 駆動で値を作る
+printf '\n- %s\n' "$line" >> shared_state.md
+```
+
+`shared_state.md` は**人間可読**を維持する。エージェントがコンテキストとして
+読むため、台帳のノイズは token コストに直結する。
+
+## 読み取りパターン
+
+各エージェントは turn 開始時に以下を読む:
+
+1. `contract.md` — sprint の真実
+2. `shared_state.md` — 台帳要約
+3. 直前の相手役の `feedback/*.md`（存在すれば）
+4. `../../progress.md` の末尾（Boot Sequence）
+5. `../../_state.json`（Boot Sequence）
+
+エージェントは**デフォルトでは**他エージェントの過去 feedback を読まない。
+Orchestrator が特定の過去ファイルをコンテキストに必要と判断すれば、プロンプト
+に stitch する。feedback をデフォルト読取から外すことで、長 sprint でも turn
+毎の token budget を安定させる。
+
+## Atomic 書き込みの規律（Orchestrator 側）
+
+atomic 性を要求する 3 ファイル:
+
+1. **`_state.json`** — 全書き込みは:
+   ```bash
+   jq '<delta>' .harness/_state.json > .harness/_state.json.tmp
+   mv .harness/_state.json.tmp .harness/_state.json
+   ```
+   同一ファイルシステム内の `mv` は macOS / Linux で atomic。
+
+2. **`metrics.jsonl`** — 常に JSON 1 行 append。編集禁止。crash 時の
+   部分書きは許容（tail reader が不正 JSON をスキップ）。
+
+3. **`shared_state.md`** — 各 append は単一 `printf`。read 側は
+   終端行が read 途中で到達しても line-oriented パーサで許容。
+
+append-only 規律により、crash 後の復旧は
+`git checkout -- path/to/file` で最後のコミット状態に戻し、Orchestrator が
+`_state.json` + ディスク上に見える feedback ファイルから再構成する。
+
+## Feedback ファイルの汎用スキーマ
+
+`feedback/{role}-<n>.md` は共通形状:
+
+```markdown
+---
+role: <planner|generator|evaluator>
+iter: <n>              # または交渉中は round: <r>
+sprint: <sprint-number>
+ts: <ISO-8601-UTC>
+# 任意、役割固有: negotiation-protocol.ja.md 参照
+---
+
+## Summary
+
+<1 パラグラフ、1〜3 文>
+
+## Details
+
+<自由記述 markdown; コード、ログ、evidence ポインタ可>
+
+## Next action
+
+<このエージェントが次に期待する動作; 空でも可>
+```
+
+Orchestrator は `Summary` を `shared_state.md` 行の構築に利用。Details と
+evidence ポインタは feedback ファイル側に残す。
+
+## 競合ケースと是正
+
+| ケース | 是正 |
+|---|---|
+| 同一 iter で 2 エージェントが同じ `feedback/*` に書いた（bug） | Orchestrator が後発を `*.dup.<ts>.md` にリネームし progress.md にログ |
+| エージェントが `shared_state.md` を直接編集 | Step 7 の commit 時に `git status` に出る。Orchestrator が revert（`git checkout --`）してログ |
+| エージェントが `_state.json` に書き込み | 禁止。Orchestrator がメモリ + feedback 内容から正しい値に上書きしログ。破損なら halt してユーザ提示 |
+| Evaluator が存在しない evidence を参照 | テスト基盤障害として扱う。verdict を `fail`（`reason: evidence-missing`）、Principal Skinner の stagnation で再発検知 |
+
+## なぜ Shared-read / Isolated-write か
+
+- **race 排除**: sub-agent 並列 dispatch 時に同一ファイルへ書き込みが
+  衝突すると torn write が起きる。書き込みを分離することで種別として排除。
+- **エージェント単位の監査性**: "iter-5 で Generator は何を考えたか" が
+  `cat feedback/generator-5.md` で 1 ファイル 1 著者として完結する。
+- **要約と詳細の分離**: 台帳は短く（event 毎 1 行）保ち、熟考は feedback
+  に置く。台帳コストしか払わない将来のエージェントは O(sprint イベント)
+  tokens で済み、O(全エージェント出力) を支払わない。
+- **Replay**: 監査者は contract.md + shared_state.md + feedback/*-<iter>.md
+  を順に読めばどの iteration も再構成できる。
+
+設計参照: `.specs/harness-suite/design.md` §9.5

--- a/skills/harness-loop/references/shared-state-protocol.md
+++ b/skills/harness-loop/references/shared-state-protocol.md
@@ -1,0 +1,171 @@
+# Shared-read / Isolated-write Protocol
+
+Covers REQ-030 and REQ-074. During a sprint, multiple agents
+(Planner, Generator, Evaluator) plus the Orchestrator all read the
+same `shared_state.md` ledger, but only the Orchestrator writes to it.
+Every other agent writes to a private `feedback/{role}-{iter}.md`
+file. This keeps the ledger race-free and auditable per-iteration.
+
+## File layout (per sprint)
+
+```
+.harness/<epic>/sprints/sprint-<n>-<feature>/
+├── contract.md                     ← frozen after negotiation (Orchestrator writes, all read)
+├── shared_state.md                 ← Orchestrator only writes; all agents read
+├── feedback/
+│   ├── planner-ruling.md           ← Planner only writes (negotiation stalemate)
+│   ├── planner-<iter>.md           ← Planner only writes (rare: replan requests)
+│   ├── generator-<round>.md        ← Generator only writes (negotiation rounds)
+│   ├── generator-<iter>.md         ← Generator only writes (impl iterations)
+│   ├── evaluator-<round>.md        ← Evaluator only writes (negotiation rounds)
+│   └── evaluator-<iter>.md         ← Evaluator only writes (impl iterations)
+└── evidence/                       ← Evaluator writes run artefacts; all read
+```
+
+Negotiation rounds are keyed by `<round>` (1..3). Implementation
+iterations are keyed by `<iter>` (1..max_iterations). Numbering spaces
+do not overlap in filenames because the prefix (`-<round>.md` vs
+`-<iter>.md`) is distinguished by `contract.status` at write time:
+`negotiating` → `round`, `active` → `iter`.
+
+Implementation inside harness-loop: keep both series in the same
+directory with distinct numbering ranges so the Orchestrator can tell
+round from iter via `contract.status` at read time.
+
+## Write permissions (authoritative)
+
+| Path | Orchestrator | Planner | Generator | Evaluator |
+|---|---|---|---|---|
+| `contract.md` frontmatter | ✅ freeze only | ❌ | ❌ | ❌ |
+| `contract.md` Negotiation Log | ✅ copy from feedback | ❌ | ❌ | ❌ |
+| `shared_state.md` | ✅ sole writer | ❌ | ❌ | ❌ |
+| `feedback/planner-*.md` | ❌ | ✅ | ❌ | ❌ |
+| `feedback/generator-*.md` | ❌ | ❌ | ✅ | ❌ |
+| `feedback/evaluator-*.md` | ❌ | ❌ | ❌ | ✅ |
+| `evidence/*` | ❌ | ❌ | ❌ | ✅ |
+| `_state.json` | ✅ sole writer | ❌ | ❌ | ❌ |
+| `metrics.jsonl` | ✅ sole writer | ❌ | ❌ | ❌ |
+| `progress.md` | ✅ direct append | via PostToolUse hook | via PostToolUse hook | via PostToolUse hook |
+
+`progress.md` is the one shared log where agent writes reach via the
+`.harness/scripts/progress-append.sh` hook, not direct file
+manipulation. The hook path is race-safe because `>>` appends are
+atomic for small writes on POSIX filesystems.
+
+## `shared_state.md` section ownership
+
+The template already carries section comments declaring ownership. In
+summary:
+
+| Section | Populated when | Orchestrator action |
+|---|---|---|
+| `## Plan` | On sprint entry | Copy from contract.md `goal` + `acceptance_scenarios` |
+| `## Contract` | On contract freeze | Write `sprint-<n>-contract.md @ <SHA>` |
+| `## Negotiation` | After each round | Append 2 lines (G + E) per round; ruling line on stalemate |
+| `## WorkLog` | After each Generator turn | Append 1 line: iter, agent, commit, summary pointer |
+| `## Evaluation` | After each Evaluator turn | Append 1 line: iter, verdict, per-axis scores, evidence pointer |
+| `## Decisions` | On state transitions | Append 1 line: decision type, reason, commit SHA |
+
+Every append is a new line, never an in-place edit. The canonical
+append implementation:
+
+```bash
+# Pseudocode; real Orchestrator path uses jq-driven values
+printf '\n- %s\n' "$line" >> shared_state.md
+```
+
+`shared_state.md` must remain human-readable. Agents read it for
+context — noise in the ledger costs them tokens.
+
+## Read patterns
+
+Every agent, at turn start, reads:
+
+1. `contract.md` — ground truth for the sprint
+2. `shared_state.md` — ledger summary of everything so far
+3. The immediately prior counterpart's `feedback/*.md` file (if any)
+4. `../../progress.md` tail (Boot Sequence)
+5. `../../_state.json` (Boot Sequence)
+
+Agents do NOT read other agents' historical feedback files by default.
+If the Orchestrator wants a specific old file in context, it stitches
+it into the prompt. Keeping feedback files out of default reads keeps
+per-turn token budgets stable across long sprints.
+
+## Atomic write discipline (Orchestrator side)
+
+Three files demand atomicity:
+
+1. **`_state.json`** — every write is:
+   ```bash
+   jq '<delta>' .harness/_state.json > .harness/_state.json.tmp
+   mv .harness/_state.json.tmp .harness/_state.json
+   ```
+   `mv` within the same filesystem is atomic on macOS and Linux.
+
+2. **`metrics.jsonl`** — always append a single JSON line; never edit.
+   A partially-written line on crash is acceptable (tail reader skips
+   invalid JSON).
+
+3. **`shared_state.md`** — each append is one `printf` call. Readers
+   tolerate the final line arriving mid-read because the parser is
+   line-oriented.
+
+The append-only discipline means recovery after crash is: `git
+checkout -- path/to/file` restores the last committed state, and the
+Orchestrator rebuilds from `_state.json` + the feedback files it can
+see on disk.
+
+## Feedback file schema (generic)
+
+All `feedback/{role}-<n>.md` share a common shape:
+
+```markdown
+---
+role: <planner|generator|evaluator>
+iter: <n>              # or round: <r> during negotiation
+sprint: <sprint-number>
+ts: <ISO-8601-UTC>
+# optional, role-specific: see negotiation-protocol.md
+---
+
+## Summary
+
+<one paragraph, 1–3 sentences>
+
+## Details
+
+<freeform markdown; may include code, logs, evidence pointers>
+
+## Next action
+
+<what this agent expects to happen next; may be empty>
+```
+
+The Orchestrator reads `Summary` to build `shared_state.md` entries.
+Details and evidence pointers stay in the feedback file for audit.
+
+## Conflict cases and remediation
+
+| Case | Remediation |
+|---|---|
+| Two agents wrote to the same `feedback/*` path in the same iter (bug) | Orchestrator renames the later file to `*.dup.<ts>.md`, logs to progress.md |
+| Agent edits `shared_state.md` directly | `git status` shows the change at Step 7 commit; Orchestrator reverts the edit (`git checkout --`) and logs |
+| Agent writes `_state.json` | Forbidden. Orchestrator overwrites with a correct value from memory + feedback file contents; logs. If `_state.json` was corrupted, halt and surface |
+| Evaluator references missing evidence | Treat as test infrastructure failure: evaluator verdict becomes `fail` with `reason: evidence-missing`; Principal Skinner's stagnation logic catches repeated cases |
+
+## Why Shared-read / Isolated-write
+
+- **Race elimination**: multiple agents writing the same file under
+  concurrent sub-agent dispatch causes torn writes; isolating writes
+  removes the class entirely.
+- **Per-agent audit**: reviewing "what did the Generator think on
+  iter-5" is `cat feedback/generator-5.md` — one file, one author.
+- **Summary vs detail separation**: the ledger stays short (one line
+  per event) while feedback files hold the deliberation. Future agents
+  paying only the ledger cost see O(sprint events) tokens, not
+  O(all agent output).
+- **Replay**: an auditor can reconstruct any iteration by reading
+  contract.md + shared_state.md + feedback/*-<iter>.md in order.
+
+Design reference: `.specs/harness-suite/design.md` §9.5.


### PR DESCRIPTION
## 概要

`/harness` シリーズ 4 スキル中 M4 の **`harness-loop`** を実装。`harness-plan` が出力した sprint バックログを受け取り、Negotiation → Implementation → PR のパイプラインを sprint ごとに回すコントロールループ本体。コンテキスト自動コンパクト耐性 (progress.md + _state.json + git + metrics.jsonl) と Principal Skinner 停止条件 5 種を核に、interactive / continuous / autonomous-ralph / scheduled の 4 実行モードに対応。

Closes #37。親ブランチ `feature/issue-32-harness-suite` 宛て。

## 実装サマリ

| タスク | 成果物 | 行数 |
|---|---|---|
| T-030 | `skills/harness-loop/SKILL.md` (10-step Orchestrator flow) | 495 |
| T-031 | `references/negotiation-protocol.{md,ja.md}` | 232 / 225 |
| T-032 | `references/shared-state-protocol.{md,ja.md}` | 171 / 163 |
| T-033 | SKILL.md Step 6 (実装ループ制御) に埋め込み | — |
| T-034 | `references/pr-creation-guide.{md,ja.md}` | 270 / 260 |
| T-035 | SKILL.md Step 9 (sprint 遷移) に埋め込み | — |
| T-036 | SKILL.md Step 7 (state 更新 + git commit + metrics append) に埋め込み | — |
| T-037 | `references/autonomous-ralph.{md,ja.md}` + SKILL.md Step 2 | 198 / 197 |
| T-038 | SKILL.md Step 6/7 の Principal Skinner 5 条件に埋め込み | — |
| T-039 | `references/otlp-exporter.{md,ja.md}` (P2 optional) | 159 / 156 |

README.md / README.ja.md の skills テーブルと install コマンドに harness-loop を 1 行ずつ追加。

## 設計ポイント

### 10-step Orchestrator フロー

1. **Detect State, Pin Generator Backend, Compute Context** — Boot Sequence + `effective_generator_backend` 固定 (REQ-060 の codex_cmux → claude フォールバック含む)
2. **Execution Mode Selection** — `interactive` のみ AskUserQuestion 許容 (ASM-007)。他 3 モードは CLI フラグまたは既存 state から解決
3. **Load Current Sprint** — roadmap.md + contract.md + shared_state.md
4. **Negotiation Phase** — Generator ⇄ Evaluator 最大 3 往復、停滞時 Planner 強制裁定
5. **Contract Freeze and Commit** — sprint ディレクトリ全体を 1 commit (feedback/ 含む監査証跡)
6. **Implementation Loop** — verdict 判定を checkpoint より先に完結させ atomic 書き込みに備える
7. **Iteration Checkpoint and Principal Skinner** — contract.md / _state.json / metrics.jsonl / git commit を 1 checkpoint で永続化。interactive モードは continue / restart / pause / abort ゲート (REQ-076) を挟む
8. **PR Creation** — split / bundled 両対応。`gh pr create` と tracker 分岐
9. **Sprint Transition** — 次 sprint or epic 完了
10. **Final Summary** — PR URL 一覧 + コスト・時間・iter 数の最終レポート

### Principal Skinner 停止条件 (REQ-080, 5 条件)

| 条件 | 発火条件 | デフォルト |
|---|---|---|
| `iteration >= max_iterations` | contract + state | 8 |
| `wall_time >= max_wall_time_sec` | `now - start_time` | 28800 (8h) |
| `rubric_stagnation_count >= rubric_stagnation_n` | state + config | 3 |
| `cumulative_cost_usd >= max_cost_usd` | state + config | $20 |
| `pending_human == true` | tier-a-guard.sh が設定 | — |

5 条件すべて SKILL.md と autonomous-ralph.md の両方でシェルラッパー側と整合する形で実装。

### Shared-read / Isolated-write (REQ-030, REQ-074)

| パス | 書き手 |
|---|---|
| `shared_state.md`, `_state.json`, `metrics.jsonl` | Orchestrator のみ |
| `feedback/{planner,generator,evaluator}-*.md` | 各エージェント自身のみ |
| `progress.md` | 全員 (PostToolUse hook 経由) |

race 排除 + エージェント単位の監査性 + 要約/詳細分離 + iter 再構成可能性を担保。詳細と権限マトリクスは `shared-state-protocol.md`。

### 状態契約の追加キー (harness-plan と非衝突)

- `_state.json.effective_generator_backend` — Step 1 で解決した backend
- `_state.json.sprint_prs[<n>]` — PR URL のマップ (`sprint_issues[<n>]` (Issue URL) とは別キー; harness-plan の既存契約は不変)
- `_state.json.pr_model` — `flat` | `stack` (epic 内で固定)

## Codex セカンドオピニオン対応

PR 作成前に `/cmux-second-opinion` で Codex にレビューを依頼し、A (Must) 5 件 / B (Should) 3 件 / C (FYI) 0 件の指摘を受領。M3 と同方針で以下のように解消:

| # | 分類 | 指摘 | 対応コミット |
|---|---|---|---|
| A1 | Must | `_state.json.sprint_issues[<n>].pr` のネストが harness-plan 契約と型衝突 | ca7254c: additive キー `sprint_prs` に分離 |
| A2 | Must | `_config.yml` に未定義のキー (`default_mode`, `default_branch`, `pr_stack`, `pr_reviewers`, `scheduled_ralph_every`) 参照 | ca7254c + db71f59: CLI フラグ / 環境変数 / runtime 解決に置換。harness-init 変更は不要 |
| A3 | Must | Step 7 checkpoint に verdict / phase / contract.status / Sprint Outcome が含まれず、最終 iter 直後 crash で resume 壊れる | ca7254c: Step 6 で verdict 決定 → Step 7 で atomic 書き込み |
| A4 | Must | interactive モードの per-iter 確認と REQ-076 restart が未実装 | ca7254c: continue / restart / pause / abort の AskUserQuestion ゲートを Step 7 後に追加 |
| A5 | Must | REQ-060 の codex_cmux → claude フォールバックが未記載 | ca7254c: Step 1 で `command -v cmux` を検査し progress.md に警告出しつつフォールバック |
| B1 | Should | `rubric-presets.md` への参照パスが壊れている | db71f59: `../../harness-init/references/rubric-presets.md` に修正 |
| B2 | Should | Negotiation 後の freeze commit に feedback/ が含まれていない | db71f59: Step 5 の `git add` を sprint ディレクトリ全体に拡大 |
| B3 | Should | harness-init が出荷しない `ralph-loop.sh` / `metrics-exporter.sh` を「harness-init places」と記載 | db71f59: autonomous-ralph (EN/JA) は「harness-loop Step 2 が書き出す」、otlp-exporter (EN/JA) は「v1 では手動作成」と downgrade |

`otlp_endpoint` のみ design §9.8 で正準 (REQ-092) なので残置。harness-init への hearing 追加は M5/M6 のスコープ。

## 制約遵守

- SKILL.md 495 行 (≤500) / references 156〜270 行 (250 目安、pr-creation-guide は両言語で 270/260 だが内容密度を優先)
- 英語本文 + Language Rules セクション / 全 AskUserQuestion バイリンガル
- バイリンガル `*.md` / `*.ja.md` ペア揃い
- MCP ツール名ハードコードなし (ripgrep 確認済)
- stdin JSON + jq (ASM-005) / non-interactive モードで AskUserQuestion 禁止 (ASM-007) / `claude -p --bare` で Ralph ループ (REQ-079)

## 非対象 (M5 以降)

- 失敗ログからのルール自動 refine → **M5 harness-rules-update**
- E2E スモークテスト (Negotiation 失敗・コンパクト耐性・Prompt Injection・Tier-A・Autonomous オーバーナイト) → **M6**
- `harness-init` 側への `otlp_endpoint` / `ralph_every` hearing 追加 → M5/M6 で合わせて検討

## 動作確認 (未検証)

本 PR は設計ドキュメント一式。実 Claude Code からの `/harness-loop` 起動検証は M6 の E2E タスク (T-053〜T-057) で行う。

## チェックリスト

- [x] SKILL.md 行数 ≤ 500
- [x] references 行数 ≤ 250 目安
- [x] バイリンガル `*.md` / `*.ja.md` ペア揃い
- [x] MCP ツール名ハードコードなし
- [x] frontmatter `name` とディレクトリ名一致
- [x] Language Rules セクションあり
- [x] README.md / README.ja.md 更新
- [x] 全 AskUserQuestion バイリンガル
- [x] Codex セカンドオピニオン指摘 A/B 全件対応
- [x] `.specs/harness-suite/_handoff.md` を M5 向けに更新 (gitignore 対象、commit せず)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
