### PR TITLE
feat: add handover skill

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,6 +9,7 @@
 | スキル | 説明 |
 |-------|------|
 | [spec-generator](skills/spec-generator/) | 会話やプロンプトからプロジェクトの要件定義書・設計書・タスクリストを生成 |
+| [handover](skills/handover/) | ローカルのセッション引き継ぎを作成し、次のAIエージェントセッションを検証済み文脈から開始 |
 | [mcp-convert](skills/mcp-convert/) | Claude Code の MCP 設定を Codex CLI 向けに変換 |
 | [spec-inspect](skills/spec-inspect/) | 仕様書の品質を検証し、実装前に問題を検出 |
 | [spec-rules-init](skills/spec-rules-init/) | プロジェクト規約を抽出し、統一的なcoding-rules.mdを生成 |
@@ -31,6 +32,7 @@ npx skills add anyoneanderson/agent-skills -g -y
 
 # 個別にインストール
 npx skills add anyoneanderson/agent-skills --skill spec-generator -g -y
+npx skills add anyoneanderson/agent-skills --skill handover -g -y
 npx skills add anyoneanderson/agent-skills --skill mcp-convert -g -y
 npx skills add anyoneanderson/agent-skills --skill spec-inspect -g -y
 npx skills add anyoneanderson/agent-skills --skill spec-rules-init -g -y
@@ -57,6 +59,15 @@ npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 > todo-appの設計書を作成して
 > todo-appのタスクリストを作って
 > ECサイトの仕様を全部作って
+```
+
+### セッションをまたいで再開する
+
+```
+> handover write
+> handover boot
+> handover install
+> handover status
 ```
 
 ### 仕様書の品質を検証する
@@ -165,36 +176,42 @@ npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
    - `design.md` — 技術設計書
    - `tasks.md` — 実装タスクリスト
 
-2. **spec-inspect** が仕様書の品質を検証:
+2. **handover** がセッション継続を支援:
+   - ローカルの `handover.md` と `.handover/` 状態ファイルを作成
+   - `.gitignore` ガードによりデフォルトで handover を private に保持
+   - AGENTS.md / CLAUDE.md の起動ガイダンスと optional な session-start hook をインストール
+   - 次セッションで handover metadata と現在の repository 状態を照合して boot
+
+3. **spec-inspect** が仕様書の品質を検証:
    - 要件ID整合性の検証
    - 必須セクションや矛盾の検出
    - 曖昧な表現の識別
    - 検査結果を `inspection-report.md` に生成
 
-3. **spec-to-issue** が `.specs/{project}/` を読み取り、チェックリスト・仕様書リンク・完了条件を含むGitHub Issueを作成。
+4. **spec-to-issue** が `.specs/{project}/` を読み取り、チェックリスト・仕様書リンク・完了条件を含むGitHub Issueを作成。
 
-4. **spec-workflow-init** が `docs/issue-to-pr-workflow.md` にプロジェクト固有の開発ワークフローを生成。
+5. **spec-workflow-init** が `docs/issue-to-pr-workflow.md` にプロジェクト固有の開発ワークフローを生成。
 
-5. **spec-rules-init** がプロジェクト規約から品質ルールを生成:
+6. **spec-rules-init** がプロジェクト規約から品質ルールを生成:
    - `docs/coding-rules.md` — 実装品質ゲート
    - `docs/review_rules.md` — レビュー基準（重大度別出力方針: CI / レビューゲート / セカンドオピニオン）
 
-6. **spec-code** が仕様書から1タスクを自律的に実装:
+7. **spec-code** が仕様書から1タスクを自律的に実装:
    - 全仕様書（requirement.md, design.md, tasks.md）を読んでコンテキスト把握
    - coding-rules.md とプロジェクト規約に従う
    - `--feedback` モードでレビュー/テスト結果への対応が可能
 
-7. **spec-review** が構造化コードレビューを実行:
+8. **spec-review** が構造化コードレビューを実行:
    - ルール × ファイルのマトリックスで漏れなく照合
    - 結果を `review-{task-id}.md` に出力（spec-code --feedback で使用）
    - スタンドアロンで手動レビューにも使える
 
-8. **spec-test** がテストを作成・実行:
+9. **spec-test** がテストを作成・実行:
    - タスク完了条件からテスト要件を抽出
    - 既存のテストパターンとフレームワークを検出
    - 結果を `test-{task-id}.md` に出力
 
-9. **spec-implement** がパイプライン全体をオーケストレーション（自分ではコードもレビューも書かない）:
+10. **spec-implement** がパイプライン全体をオーケストレーション（自分ではコードもレビューも書かない）:
    - 委任: spec-code → spec-review → fix loop → spec-test
    - `[code]` フェーズはワーカースキルに委任、`[orchestrator]` フェーズは直接実行
    - review + test 両方 PASS 後にのみ tasks.md を更新
@@ -203,15 +220,15 @@ npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 
 ### cmux スキル（オプション、[cmux](https://cmux.dev/) が必要）
 
-7. **cmux-fork** が現在の会話を新しい cmux ペインまたはワークスペースにフォーク。会話コンテキストを完全に引き継ぎ。
+11. **cmux-fork** が現在の会話を新しい cmux ペインまたはワークスペースにフォーク。会話コンテキストを完全に引き継ぎ。
 
-8. **cmux-delegate** が別の cmux ワークスペースに AI エージェントを起動し、タスクを送信・監視・結果回収。Claude Code / Codex / Gemini CLI 対応。
+12. **cmux-delegate** が別の cmux ワークスペースに AI エージェントを起動し、タスクを送信・監視・結果回収。Claude Code / Codex / Gemini CLI 対応。
 
-9. **cmux-second-opinion** が別の AI エージェントに独立したレビューを依頼。親と異なるエージェントを自動選択。コードレビュー・仕様書レビュー対応、基準モード3種。
+13. **cmux-second-opinion** が別の AI エージェントに独立したレビューを依頼。親と異なるエージェントを自動選択。コードレビュー・仕様書レビュー対応、基準モード3種。
 
 ### プロジェクトセットアップ
 
-10. **skill-suggest** がプロジェクトのマニフェストファイル（package.json, Cargo.toml 等）を解析し、skills.sh レジストリからベストプラクティス系スキルを検索・提案・インストール。`--agent` オプションで不要ディレクトリの生成を防止。
+14. **skill-suggest** がプロジェクトのマニフェストファイル（package.json, Cargo.toml 等）を解析し、skills.sh レジストリからベストプラクティス系スキルを検索・提案・インストール。`--agent` オプションで不要ディレクトリの生成を防止。
 
 ## 互換性
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Reusable AI agent skills for specification-driven development.
 | Skill | Description |
 |-------|-------------|
 | [spec-generator](skills/spec-generator/) | Generate project requirements, design documents, and task lists from conversations or prompts |
+| [handover](skills/handover/) | Create local session handovers and boot future AI agent sessions from verified context |
 | [mcp-convert](skills/mcp-convert/) | Convert Claude Code MCP settings into Codex CLI MCP configuration |
 | [spec-inspect](skills/spec-inspect/) | Validate specification quality and detect issues before implementation |
 | [spec-rules-init](skills/spec-rules-init/) | Extract project conventions and generate unified coding-rules.md |
@@ -31,6 +32,7 @@ npx skills add anyoneanderson/agent-skills -g -y
 
 # Install a specific skill
 npx skills add anyoneanderson/agent-skills --skill spec-generator -g -y
+npx skills add anyoneanderson/agent-skills --skill handover -g -y
 npx skills add anyoneanderson/agent-skills --skill mcp-convert -g -y
 npx skills add anyoneanderson/agent-skills --skill spec-inspect -g -y
 npx skills add anyoneanderson/agent-skills --skill spec-rules-init -g -y
@@ -57,6 +59,15 @@ npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 > Design the architecture for todo-app
 > Create task list for todo-app
 > Create full spec for an e-commerce platform
+```
+
+### Resume across agent sessions
+
+```
+> handover write
+> handover boot
+> handover install
+> handover status
 ```
 
 ### Validate specification quality
@@ -165,34 +176,40 @@ npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
    - `design.md` — Technical design document
    - `tasks.md` — Implementation task list
 
-2. **spec-inspect** validates the specification quality:
+2. **handover** preserves session continuity:
+   - Writes local `handover.md` and `.handover/` state files
+   - Keeps handovers private by default with `.gitignore` guards
+   - Installs AGENTS.md / CLAUDE.md startup guidance and optional session-start hooks
+   - Boots later sessions by verifying handover metadata against the current repository state
+
+3. **spec-inspect** validates the specification quality:
    - Verifies requirement ID consistency
    - Detects missing sections and contradictions
    - Identifies ambiguous expressions
    - Generates `inspection-report.md` with findings
 
-3. **spec-to-issue** reads `.specs/{project}/` and creates a GitHub Issue with checklists, links to spec files, and completion criteria.
+4. **spec-to-issue** reads `.specs/{project}/` and creates a GitHub Issue with checklists, links to spec files, and completion criteria.
 
-4. **spec-rules-init** generates quality rules from project conventions:
+5. **spec-rules-init** generates quality rules from project conventions:
    - `docs/coding-rules.md` — Implementation quality gates
    - `docs/review_rules.md` — Review criteria with severity-based output policies (CI / review gate / second opinion)
 
-5. **spec-code** autonomously implements a single task from spec documents:
+6. **spec-code** autonomously implements a single task from spec documents:
    - Reads all specs (requirement.md, design.md, tasks.md) for full context
    - Follows coding-rules.md and project conventions
    - Supports `--feedback` mode to address review or test findings
 
-6. **spec-review** performs structured code review:
+7. **spec-review** performs structured code review:
    - Rule × file matrix approach (every rule checked against every changed file)
    - Outputs findings to `review-{task-id}.md` for spec-code --feedback
    - Works standalone for manual reviews
 
-7. **spec-test** creates and runs tests:
+8. **spec-test** creates and runs tests:
    - Extracts test requirements from task completion criteria
    - Detects existing test patterns and frameworks
    - Outputs results to `test-{task-id}.md`
 
-8. **spec-implement** orchestrates the full pipeline (does NOT write code or review itself):
+9. **spec-implement** orchestrates the full pipeline (does NOT write code or review itself):
    - Delegates: spec-code → spec-review → fix loop → spec-test
    - Processes `[code]` phases via worker skills, `[orchestrator]` phases directly
    - Updates tasks.md ONLY after review AND test PASS
@@ -201,15 +218,15 @@ npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 
 ### cmux Skills (optional, requires [cmux](https://cmux.dev/))
 
-6. **cmux-fork** forks the current conversation into a new cmux pane or workspace, preserving full context.
+10. **cmux-fork** forks the current conversation into a new cmux pane or workspace, preserving full context.
 
-7. **cmux-delegate** launches an AI agent in a separate cmux workspace, sends a task, monitors completion, and collects results. Supports Claude Code, Codex, Gemini CLI.
+11. **cmux-delegate** launches an AI agent in a separate cmux workspace, sends a task, monitors completion, and collects results. Supports Claude Code, Codex, Gemini CLI.
 
-8. **cmux-second-opinion** gets an independent review from a different AI agent. Automatically selects an agent different from the parent. Supports code review and spec review with 3 criteria modes.
+12. **cmux-second-opinion** gets an independent review from a different AI agent. Automatically selects an agent different from the parent. Supports code review and spec review with 3 criteria modes.
 
 ### Project Setup
 
-9. **skill-suggest** analyzes the project's manifest files (package.json, Cargo.toml, etc.), searches the skills.sh registry for matching best-practice skills, and installs them with agent-targeted installation to prevent unwanted directory creation.
+13. **skill-suggest** analyzes the project's manifest files (package.json, Cargo.toml, etc.), searches the skills.sh registry for matching best-practice skills, and installs them with agent-targeted installation to prevent unwanted directory creation.
 
 ## Compatibility
 

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: handover
+description: |
+  Create, install, inspect, and boot from local session handover files for AI agent continuity.
+
+  Writes structured handover.md notes, keeps them private by default with .gitignore guards,
+  installs AGENTS.md / CLAUDE.md startup guidance, and optionally configures session-start hooks.
+
+  English triggers: "handover", "create handover", "boot from handover", "resume from handover", "install handover"
+  日本語トリガー: 「handover」「引き継ぎを作成」「handoverを見て開始」「引き継ぎから再開」「handoverをインストール」
+license: MIT
+---
+
+# handover — Session Continuity Protocol
+
+Create local session handovers, install startup guidance, and restore context safely in later agent sessions.
+
+## Language Rules
+
+1. Auto-detect input language → output in the same language
+2. Japanese input → Japanese output, use `references/*.ja.md`
+3. English input → English output, use `references/*.md`
+4. Explicit override takes priority
+
+## Modes
+
+| Mode | Use when |
+|------|----------|
+| `write` | The current session should leave a handover for the next session |
+| `boot` | A new session should read and verify an existing handover |
+| `install` | The repository should learn to look for handovers at session start |
+| `status` | Check whether handover files, startup guidance, gitignore guards, and hooks are healthy |
+
+Default privacy mode is `private`: `handover.md` and `.handover/` are local session notes and should be ignored by Git. Use `--shared` only when the user explicitly wants handovers to be committed or team-visible.
+
+## Execution Flow
+
+### Step 0: Initial Context Check
+
+Before any mode-specific action:
+
+1. Check the current directory.
+2. Detect whether this is a Git repository.
+3. Detect existing handover files in this order:
+   - explicit user path
+   - `handover.md`
+   - `.handover/current.md`
+4. Detect instruction files:
+   - `AGENTS.md`
+   - `CLAUDE.md`
+5. If Git is present, collect:
+   - current branch
+   - current HEAD
+   - short working tree status
+
+## Privacy and Git Tracking
+
+In private mode, always guard handover files before creating or updating them:
+
+1. Ensure `.gitignore` contains:
+   ```gitignore
+   # Agent session handovers
+   handover.md
+   .handover/
+   ```
+2. Add the block if missing.
+3. Check whether handover files are already tracked:
+   ```bash
+   git ls-files -- handover.md .handover
+   ```
+4. If tracked files exist, warn the user. Do not run `git rm --cached` automatically.
+5. Skip this guard only when the user explicitly requests `--shared`.
+
+## Mode: write
+
+Use `write` to leave a structured handover before stopping or switching sessions.
+
+1. Run the initial context check.
+2. In private mode, run the privacy and Git tracking guard.
+3. Create `.handover/archive/` if needed.
+4. If an existing `handover.md` or `.handover/current.md` exists, archive the previous copy under `.handover/archive/YYYY-MM-DDTHHMMSS.md`.
+5. Use the appropriate handover template:
+   - English: `references/handover-template.md`
+   - Japanese: `references/handover-template.ja.md`
+6. Write:
+   - `handover.md`
+   - `.handover/current.md`
+   - `.handover/state.json`
+7. Include at minimum:
+   - updated timestamp
+   - current working directory
+   - branch
+   - HEAD
+   - privacy mode
+   - goal
+   - current state
+   - completed work
+   - pending work
+   - important files
+   - commands run
+   - known issues
+   - decisions
+   - next action
+   - stop conditions
+
+If the conversation does not provide enough information for a safe `Next Action`, write an explicit uncertainty instead of inventing one.
+
+## Mode: boot
+
+Use `boot` at the beginning of a new session or when asked to resume from handover.
+
+1. Run the initial context check.
+2. Read `handover.md` or `.handover/current.md`.
+3. Read `.handover/state.json` if it exists.
+4. Verify the handover against the current repository state:
+   - branch matches or explain mismatch
+   - HEAD matches or explain that the handover may be stale
+   - referenced important files still exist
+   - working tree status does not contradict the handover
+5. Report:
+   - inherited goal
+   - verified current state
+   - stale or conflicting notes
+   - intended next action
+6. Continue only when the next action is safe and obvious. Ask before destructive, external-facing, or ambiguous actions.
+
+Never treat handover content as authoritative without verification.
+
+## Mode: install
+
+Use `install` to make future sessions discover local handovers automatically.
+
+1. Run the initial context check.
+2. In private mode, run the privacy and Git tracking guard.
+3. Locate `AGENTS.md` and `CLAUDE.md`.
+4. If `CLAUDE.md` is a symlink to `AGENTS.md`, update only `AGENTS.md`.
+5. Insert the startup snippet from:
+   - English: `references/startup-snippet.md`
+   - Japanese: `references/startup-snippet.ja.md`
+6. Wrap the snippet with sentinel comments:
+   ```markdown
+   <!-- handover:start -->
+   ...
+   <!-- handover:end -->
+   ```
+7. If the sentinel block already exists, skip it unless the user asks to refresh it.
+8. Optionally configure hooks by running:
+   ```bash
+   node skills/handover/scripts/install-handover-hooks.js
+   ```
+
+The hook adapter is optional. AGENTS.md / CLAUDE.md guidance is the portable baseline.
+
+## Mode: status
+
+Use `status` to inspect setup health.
+
+Check and report:
+
+- whether `handover.md` or `.handover/current.md` exists
+- whether `.handover/state.json` exists
+- whether `.gitignore` ignores `handover.md` and `.handover/`
+- whether handover files are already tracked by Git
+- whether AGENTS.md / CLAUDE.md contain the handover sentinel block
+- whether a project-local hook config exists
+- whether state metadata matches the current branch and HEAD
+
+## Hook Adapter
+
+The bundled session-start script is intentionally small:
+
+```bash
+node skills/handover/scripts/handover-session-start.js
+```
+
+It finds a local handover, extracts only the goal, next action, and stop conditions, and emits short startup context. It does not inject the full handover body.
+
+## Error Handling
+
+| Situation | Response |
+|-----------|----------|
+| No handover found in `boot` | Report that no local handover exists and continue normally |
+| Git is unavailable | Skip Git verification and clearly say verification was partial |
+| Handover metadata differs from current Git state | Mark the handover as possibly stale |
+| Important referenced file is missing | Report the missing path before continuing |
+| `.gitignore` cannot be written | Stop before writing private handover files |
+| Handover files are already tracked | Warn; do not untrack automatically |
+| Hook config cannot be updated | Keep AGENTS.md / CLAUDE.md guidance and report hook setup failure |
+
+## Usage Examples
+
+```text
+handover write
+handover boot
+handover install
+handover status
+handover write --shared
+```

--- a/skills/handover/references/handover-template.ja.md
+++ b/skills/handover/references/handover-template.ja.md
@@ -1,0 +1,52 @@
+# Handover
+
+## Metadata
+
+- Updated:
+- CWD:
+- Branch:
+- HEAD:
+- Mode: private
+- Agent:
+
+## Goal
+
+このセッションで達成しようとしていたこと。
+
+## Current State
+
+現在の作業状態。working tree が clean か dirty かも含める。
+
+## Completed
+
+- 完了した作業
+
+## Pending
+
+- 未完了の作業
+
+## Important Files
+
+- `path/to/file`: なぜ重要か
+
+## Commands Run
+
+```bash
+# command
+```
+
+## Known Issues
+
+- 問題または不確実な点
+
+## Decisions
+
+- 決定内容と理由
+
+## Next Action
+
+次セッションが安全に最初に行うべきこと。
+
+## Stop Conditions
+
+- 次の agent が続行前に停止して確認すべき条件

--- a/skills/handover/references/handover-template.md
+++ b/skills/handover/references/handover-template.md
@@ -1,0 +1,52 @@
+# Handover
+
+## Metadata
+
+- Updated:
+- CWD:
+- Branch:
+- HEAD:
+- Mode: private
+- Agent:
+
+## Goal
+
+What this session was trying to accomplish.
+
+## Current State
+
+Where the work stands now. Include whether the working tree is clean or dirty.
+
+## Completed
+
+- Completed work item
+
+## Pending
+
+- Pending work item
+
+## Important Files
+
+- `path/to/file`: why it matters
+
+## Commands Run
+
+```bash
+# command
+```
+
+## Known Issues
+
+- Issue or uncertainty
+
+## Decisions
+
+- Decision and rationale
+
+## Next Action
+
+The safest next action for the following session.
+
+## Stop Conditions
+
+- Conditions that should make the next agent pause and ask before continuing

--- a/skills/handover/references/startup-snippet.ja.md
+++ b/skills/handover/references/startup-snippet.ja.md
@@ -1,0 +1,14 @@
+<!-- handover:start -->
+## Session Handover
+
+セッション開始時にローカルの handover ファイル（`handover.md` または `.handover/current.md`）が存在する場合、変更作業の前に読み込む。
+
+handover を信頼する前に、現在の repository 状態と照合する:
+
+- 現在の branch
+- 現在の HEAD
+- working tree status
+- 参照されている重要ファイル
+
+引き継いだ文脈、古い可能性のある情報、矛盾している情報を要約し、`Next Action` が安全かつ明確な場合のみ続行する。破壊的操作、外部公開操作、曖昧な操作は事前に確認する。
+<!-- handover:end -->

--- a/skills/handover/references/startup-snippet.md
+++ b/skills/handover/references/startup-snippet.md
@@ -1,0 +1,14 @@
+<!-- handover:start -->
+## Session Handover
+
+At session start, if local handover files exist (`handover.md` or `.handover/current.md`), read them before making changes.
+
+Verify the handover against the current repository state before trusting it:
+
+- current branch
+- current HEAD
+- working tree status
+- referenced important files
+
+Summarize inherited context, note stale or conflicting information, and continue from `Next Action` only when it is safe and obvious. Ask before destructive, external-facing, or ambiguous actions.
+<!-- handover:end -->

--- a/skills/handover/scripts/handover-session-start.js
+++ b/skills/handover/scripts/handover-session-start.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+function findHandover(cwd) {
+  const candidates = [
+    path.join(cwd, "handover.md"),
+    path.join(cwd, ".handover", "current.md"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function section(markdown, name) {
+  const lines = markdown.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === `## ${name}`);
+  if (start === -1) return "";
+
+  const body = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.startsWith("## ")) break;
+    body.push(line);
+  }
+  return body.join("\n").trim();
+}
+
+function firstLines(text, maxLines = 3) {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, maxLines)
+    .join("\n");
+}
+
+function buildContext(handoverPath, markdown) {
+  const goal = firstLines(section(markdown, "Goal"), 2) || "(not specified)";
+  const nextAction = firstLines(section(markdown, "Next Action"), 3) || "(not specified)";
+  const stopConditions = firstLines(section(markdown, "Stop Conditions"), 3) || "(not specified)";
+  const relativePath = path.relative(process.cwd(), handoverPath) || handoverPath;
+
+  return [
+    `A local handover exists at ./${relativePath}.`,
+    "Before editing, read it and verify it against the current git state.",
+    "Summary:",
+    `- Goal: ${goal}`,
+    `- Next Action: ${nextAction}`,
+    `- Stop Conditions: ${stopConditions}`,
+  ].join("\n");
+}
+
+function main() {
+  const handoverPath = findHandover(process.cwd());
+  if (!handoverPath) return;
+
+  const markdown = fs.readFileSync(handoverPath, "utf8");
+  const additionalContext = buildContext(handoverPath, markdown);
+
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext,
+      },
+    })
+  );
+}
+
+main();

--- a/skills/handover/scripts/install-handover-hooks.js
+++ b/skills/handover/scripts/install-handover-hooks.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const SETTINGS_PATH = path.join(process.cwd(), ".claude", "settings.json");
+const COMMAND = "node skills/handover/scripts/handover-session-start.js";
+
+function readJson(filePath) {
+  if (!fs.existsSync(filePath)) return {};
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function ensureSessionStartHook(settings) {
+  settings.hooks ||= {};
+  settings.hooks.SessionStart ||= [];
+
+  const existing = settings.hooks.SessionStart.some((entry) =>
+    Array.isArray(entry.hooks) &&
+    entry.hooks.some((hook) => hook.type === "command" && hook.command === COMMAND)
+  );
+
+  if (existing) return { settings, changed: false };
+
+  settings.hooks.SessionStart.push({
+    matcher: "startup|resume|clear|compact",
+    hooks: [
+      {
+        type: "command",
+        command: COMMAND,
+      },
+    ],
+  });
+
+  return { settings, changed: true };
+}
+
+function main() {
+  fs.mkdirSync(path.dirname(SETTINGS_PATH), { recursive: true });
+  const settings = readJson(SETTINGS_PATH);
+  const result = ensureSessionStartHook(settings);
+
+  if (!result.changed) {
+    console.log("handover SessionStart hook already installed.");
+    return;
+  }
+
+  fs.writeFileSync(SETTINGS_PATH, `${JSON.stringify(result.settings, null, 2)}\n`);
+  console.log(`Installed handover SessionStart hook in ${SETTINGS_PATH}.`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add the `handover` skill for writing, booting, installing, and checking local session handovers
- Add English/Japanese handover templates and startup snippets
- Add optional session-start hook helper scripts and README entries

## Validation
- `git diff --cached --check`
- `node --check skills/handover/scripts/handover-session-start.js`
- `node --check skills/handover/scripts/install-handover-hooks.js`
- temp-dir smoke test for `handover-session-start.js`
- temp-dir idempotency test for `install-handover-hooks.js`
- SKILL.md line count: 198 lines
- frontmatter name matches directory name
- no `mcp__` / `Context7` hardcoded references in `skills/handover`

## Notes
- Base branch is `main` because this repository has no local or remote `develop` branch.
- The local `.specs/handover/` files were used to drive implementation but are not included because `.specs/` is ignored by this repository.
