### PR TITLE
feat: add Codex handover hook support

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -179,7 +179,7 @@ npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 2. **handover** がセッション継続を支援:
    - ローカルの `handover.md` と `.handover/` 状態ファイルを作成
    - `.gitignore` ガードによりデフォルトで handover を private に保持
-   - AGENTS.md / CLAUDE.md の起動ガイダンスと optional な session-start hook をインストール
+   - AGENTS.md / CLAUDE.md の起動ガイダンスと optional な Claude Code / Codex session-start hook をインストール
    - 次セッションで handover metadata と現在の repository 状態を照合して boot
 
 3. **spec-inspect** が仕様書の品質を検証:

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 2. **handover** preserves session continuity:
    - Writes local `handover.md` and `.handover/` state files
    - Keeps handovers private by default with `.gitignore` guards
-   - Installs AGENTS.md / CLAUDE.md startup guidance and optional session-start hooks
+   - Installs AGENTS.md / CLAUDE.md startup guidance and optional Claude Code / Codex session-start hooks
    - Boots later sessions by verifying handover metadata against the current repository state
 
 3. **spec-inspect** validates the specification quality:

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Create, install, inspect, and boot from local session handover files for AI agent continuity.
 
   Writes structured handover.md notes, keeps them private by default with .gitignore guards,
-  installs AGENTS.md / CLAUDE.md startup guidance, and optionally configures session-start hooks.
+  installs AGENTS.md / CLAUDE.md startup guidance, and configures Claude Code / Codex session-start hooks.
 
   English triggers: "handover", "create handover", "boot from handover", "resume from handover", "install handover"
   日本語トリガー: 「handover」「引き継ぎを作成」「handoverを見て開始」「引き継ぎから再開」「handoverをインストール」
@@ -144,12 +144,13 @@ Use `install` to make future sessions discover local handovers automatically.
    <!-- handover:end -->
    ```
 7. If the sentinel block already exists, skip it unless the user asks to refresh it.
-8. Optionally configure hooks by running:
+8. Optionally configure Claude Code and Codex hooks by running:
    ```bash
    node skills/handover/scripts/install-handover-hooks.js
    ```
+   Use `--claude` or `--codex` to install only one adapter.
 
-The hook adapter is optional. AGENTS.md / CLAUDE.md guidance is the portable baseline.
+The hook adapters are optional. AGENTS.md / CLAUDE.md guidance is the portable baseline.
 
 ## Mode: status
 
@@ -162,7 +163,7 @@ Check and report:
 - whether `.gitignore` ignores `handover.md` and `.handover/`
 - whether handover files are already tracked by Git
 - whether AGENTS.md / CLAUDE.md contain the handover sentinel block
-- whether a project-local hook config exists
+- whether project-local Claude Code and Codex hook configs exist
 - whether state metadata matches the current branch and HEAD
 
 ## Hook Adapter
@@ -173,7 +174,12 @@ The bundled session-start script is intentionally small:
 node skills/handover/scripts/handover-session-start.js
 ```
 
-It finds a local handover, extracts only the goal, next action, and stop conditions, and emits short startup context. It does not inject the full handover body.
+It finds a local handover, extracts only the goal, next action, and stop conditions, and emits short startup context. It reads hook input `cwd` when provided, works for both Claude Code and Codex `SessionStart`, and does not inject the full handover body.
+
+Hook installer targets:
+
+- Claude Code: `.claude/settings.json`
+- Codex: `.codex/hooks.json`
 
 ## Error Handling
 

--- a/skills/handover/scripts/handover-session-start.js
+++ b/skills/handover/scripts/handover-session-start.js
@@ -3,6 +3,15 @@
 const fs = require("fs");
 const path = require("path");
 
+function readHookInput() {
+  try {
+    const raw = fs.readFileSync(0, "utf8").trim();
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
 function findHandover(cwd) {
   const candidates = [
     path.join(cwd, "handover.md"),
@@ -50,11 +59,16 @@ function buildContext(handoverPath, markdown) {
 }
 
 function main() {
-  const handoverPath = findHandover(process.cwd());
+  const input = readHookInput();
+  const cwd = input.cwd || process.cwd();
+  const handoverPath = findHandover(cwd);
   if (!handoverPath) return;
 
   const markdown = fs.readFileSync(handoverPath, "utf8");
+  const previousCwd = process.cwd();
+  process.chdir(cwd);
   const additionalContext = buildContext(handoverPath, markdown);
+  process.chdir(previousCwd);
 
   process.stdout.write(
     JSON.stringify({

--- a/skills/handover/scripts/install-handover-hooks.js
+++ b/skills/handover/scripts/install-handover-hooks.js
@@ -3,50 +3,112 @@
 const fs = require("fs");
 const path = require("path");
 
-const SETTINGS_PATH = path.join(process.cwd(), ".claude", "settings.json");
-const COMMAND = "node skills/handover/scripts/handover-session-start.js";
+const SESSION_SCRIPT = path.join(__dirname, "handover-session-start.js");
+const COMMAND = `node ${shellQuote(SESSION_SCRIPT)}`;
+const CLAUDE_SETTINGS_PATH = path.join(process.cwd(), ".claude", "settings.json");
+const CODEX_HOOKS_PATH = path.join(process.cwd(), ".codex", "hooks.json");
+const HANDOVER_SCRIPT_PATTERN = /handover-session-start\.js(?:'|")?$/;
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
 
 function readJson(filePath) {
   if (!fs.existsSync(filePath)) return {};
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
-function ensureSessionStartHook(settings) {
-  settings.hooks ||= {};
-  settings.hooks.SessionStart ||= [];
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
 
-  const existing = settings.hooks.SessionStart.some((entry) =>
-    Array.isArray(entry.hooks) &&
-    entry.hooks.some((hook) => hook.type === "command" && hook.command === COMMAND)
-  );
+function hookMatches(hook) {
+  return hook.type === "command" && (hook.command === COMMAND || HANDOVER_SCRIPT_PATTERN.test(hook.command || ""));
+}
 
-  if (existing) return { settings, changed: false };
+function normalizeHook(entry, { includeStatusMessage }) {
+  let changed = false;
+  for (const hook of entry.hooks || []) {
+    if (!hookMatches(hook)) continue;
+    if (hook.command !== COMMAND) {
+      hook.command = COMMAND;
+      changed = true;
+    }
+    if (hook.timeout == null) {
+      hook.timeout = 5;
+      changed = true;
+    }
+    if (includeStatusMessage && !hook.statusMessage) {
+      hook.statusMessage = "Injecting handover context";
+      changed = true;
+    }
+  }
+  return changed;
+}
 
-  settings.hooks.SessionStart.push({
+function ensureSessionStartHook(config, { includeStatusMessage }) {
+  config.hooks ||= {};
+  config.hooks.SessionStart ||= [];
+
+  for (const entry of config.hooks.SessionStart) {
+    if (Array.isArray(entry.hooks) && entry.hooks.some(hookMatches)) {
+      return { config, changed: normalizeHook(entry, { includeStatusMessage }) };
+    }
+  }
+
+  const hook = {
+    type: "command",
+    command: COMMAND,
+    timeout: 5,
+  };
+  if (includeStatusMessage) {
+    hook.statusMessage = "Injecting handover context";
+  }
+
+  config.hooks.SessionStart.push({
     matcher: "startup|resume|clear|compact",
-    hooks: [
-      {
-        type: "command",
-        command: COMMAND,
-      },
-    ],
+    hooks: [hook],
   });
 
-  return { settings, changed: true };
+  return { config, changed: true };
+}
+
+function installClaudeHook() {
+  const settings = readJson(CLAUDE_SETTINGS_PATH);
+  const result = ensureSessionStartHook(settings, { includeStatusMessage: false });
+  if (result.changed) {
+    writeJson(CLAUDE_SETTINGS_PATH, result.config);
+    return `Installed handover SessionStart hook in ${CLAUDE_SETTINGS_PATH}.`;
+  }
+  return "handover Claude Code SessionStart hook already installed.";
+}
+
+function installCodexHook() {
+  const hooksConfig = readJson(CODEX_HOOKS_PATH);
+  hooksConfig.$comment ||= "Codex hooks for project-local agent workflows.";
+  const result = ensureSessionStartHook(hooksConfig, { includeStatusMessage: true });
+  if (result.changed) {
+    writeJson(CODEX_HOOKS_PATH, result.config);
+    return `Installed handover SessionStart hook in ${CODEX_HOOKS_PATH}.`;
+  }
+  return "handover Codex SessionStart hook already installed.";
 }
 
 function main() {
-  fs.mkdirSync(path.dirname(SETTINGS_PATH), { recursive: true });
-  const settings = readJson(SETTINGS_PATH);
-  const result = ensureSessionStartHook(settings);
+  const targets = new Set(process.argv.slice(2));
+  const installClaude = targets.size === 0 || targets.has("--claude") || targets.has("--all");
+  const installCodex = targets.size === 0 || targets.has("--codex") || targets.has("--all");
 
-  if (!result.changed) {
-    console.log("handover SessionStart hook already installed.");
-    return;
+  const messages = [];
+  if (installClaude) messages.push(installClaudeHook());
+  if (installCodex) messages.push(installCodexHook());
+  if (messages.length === 0) {
+    console.error("Usage: install-handover-hooks.js [--claude] [--codex] [--all]");
+    process.exit(1);
   }
 
-  fs.writeFileSync(SETTINGS_PATH, `${JSON.stringify(result.settings, null, 2)}\n`);
-  console.log(`Installed handover SessionStart hook in ${SETTINGS_PATH}.`);
+  console.log(messages.join("\n"));
 }
 
 main();


### PR DESCRIPTION
## Summary
- Extend the handover hook installer to configure both Claude Code and Codex session-start hooks
- Add `.codex/hooks.json` support while preserving existing hook entries and avoiding duplicate handover hooks
- Normalize existing handover hook commands to the installed script path and make the session-start script respect hook input `cwd`
- Update handover docs/README wording to mention Claude Code / Codex hook adapters

## Validation
- `node --check skills/handover/scripts/handover-session-start.js`
- `node --check skills/handover/scripts/install-handover-hooks.js`
- `git diff --check`
- temp-dir idempotency test for dual Claude/Codex hook installation
- temp-dir `cwd` smoke test for `handover-session-start.js`
- SKILL.md line count: 204 lines
- frontmatter name and description length check
- no `mcp__` / `Context7` hardcoded references in `skills/handover`, README.md, README.ja.md
