### PR TITLE
fix: add Codex agent template metadata

### DIFF
--- a/skills/harness-init/SKILL.md
+++ b/skills/harness-init/SKILL.md
@@ -246,7 +246,7 @@ Pick the language variant matching detected input: `<role>.md` (EN) or
 If `generator_backend ∈ {codex_cli, codex_cmux}` OR the project
 already has a `.codex/` directory (indicating Codex CLI is configured),
 also render Codex TOML role configs (plain `ConfigToml` layers with
-top-level `model` + `developer_instructions`):
+top-level `name` + `description` + `model` + `developer_instructions`):
 
 - `.codex/agents/planner.toml` — from `references/agent-templates/planner{.ja}.toml`
 - `.codex/agents/evaluator.toml` — from `references/agent-templates/evaluator{.ja}.toml`

--- a/skills/harness-init/references/agent-templates/evaluator.ja.toml
+++ b/skills/harness-init/references/agent-templates/evaluator.ja.toml
@@ -3,6 +3,8 @@
 # Evaluator は現行でも既定では Claude で動くが、将来 backend と対称性のため
 # Codex 向け role contract も保持する。
 
+name = "evaluator"
+description = "独立レビュー、品質ゲート、ライブ検証、交渉フィードバックを担当する Evaluator ロール。"
 model = "gpt-5.4"
 
 developer_instructions = """

--- a/skills/harness-init/references/agent-templates/evaluator.toml
+++ b/skills/harness-init/references/agent-templates/evaluator.toml
@@ -3,6 +3,8 @@
 # Currently Evaluator still runs as Claude by default, but this TOML keeps the
 # role contract mirrored for parity and future backends.
 
+name = "evaluator"
+description = "Harness Evaluator role for independent review, quality gates, live verification, and negotiation feedback."
 model = "gpt-5.4"
 
 developer_instructions = """

--- a/skills/harness-init/references/agent-templates/generator.ja.toml
+++ b/skills/harness-init/references/agent-templates/generator.ja.toml
@@ -9,6 +9,8 @@
 # （_config.yml.codex_generator_model から読む）。宣言は role overlay の
 # 既定値および将来 backend のために残す。
 
+name = "generator"
+description = "スプリント契約の実装と構造化された iteration report の作成を担当する Generator ロール。"
 model = "gpt-5.4"
 
 developer_instructions = """

--- a/skills/harness-init/references/agent-templates/generator.toml
+++ b/skills/harness-init/references/agent-templates/generator.toml
@@ -9,6 +9,8 @@
 # call, reading _config.yml.codex_generator_model. Leave the declaration
 # as a default for role overlays and future backends.
 
+name = "generator"
+description = "Harness Generator role for implementing sprint contracts and writing structured iteration reports."
 model = "gpt-5.4"
 
 developer_instructions = """

--- a/skills/harness-init/references/agent-templates/planner.ja.toml
+++ b/skills/harness-init/references/agent-templates/planner.ja.toml
@@ -4,6 +4,8 @@
 # 将来 Planner が Codex に委譲される場合のために用意。Orchestrator の
 # prompt-file がロール契約を起動する。
 
+name = "planner"
+description = "ハーネスのヒアリング、ロードマップ設計、契約ドラフト、交渉裁定を担当する Planner ロール。"
 model = "gpt-5.4"
 
 developer_instructions = """

--- a/skills/harness-init/references/agent-templates/planner.toml
+++ b/skills/harness-init/references/agent-templates/planner.toml
@@ -4,6 +4,8 @@
 # provided for parity / future use if Planner is ever routed through
 # Codex. Orchestrator prompt-file activates the role contract.
 
+name = "planner"
+description = "Harness Planner role for interviews, roadmap planning, contract drafting, and negotiation rulings."
 model = "gpt-5.4"
 
 developer_instructions = """


### PR DESCRIPTION
## 概要
- harness-init の Codex agent TOML テンプレートに top-level `name` / `description` を追加
- `planner` / `generator` / `evaluator` の英日テンプレート 6 ファイルを Codex agent role schema に合わせる
- harness-init の生成物説明を `name` / `description` 付きに更新

## 背景
Codex 起動時に `.codex/agents/*.toml` が non-empty `name` 不足として malformed warning になるため、生成元テンプレートで根本修正します。

## 検証
- `npx --yes @taplo/cli@latest check skills/harness-init/references/agent-templates/*.toml`
- `git diff --check`
- `wc -l skills/harness-init/SKILL.md skills/harness-loop/SKILL.md skills/harness-plan/SKILL.md`

Closes #63