### PR TITLE
docs: README の使い方記載漏れを補完（spec-evaluate / spec-orchestrate / agent-delegate）

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -53,6 +53,7 @@ npx skills add anyoneanderson/agent-skills --skill spec-orchestrate -g -y
 npx skills add anyoneanderson/agent-skills --skill cmux-fork -g -y
 npx skills add anyoneanderson/agent-skills --skill cmux-delegate -g -y
 npx skills add anyoneanderson/agent-skills --skill cmux-second-opinion -g -y
+npx skills add anyoneanderson/agent-skills --skill agent-delegate -g -y
 npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 
 # Harness Engineering（自律）— 先に spec-rules-init + spec-workflow-init を入れる
@@ -142,12 +143,27 @@ npx skills add anyoneanderson/agent-skills --skill harness-loop -g -y
 > /spec-test --task T-003 --spec .specs/auth-feature/
 ```
 
+### ビルドに対して受け入れ試験を実行する
+
+```
+> /spec-evaluate --spec .specs/auth-feature/
+> /spec-evaluate --spec .specs/auth-feature/ --round 2 --backend self
+```
+
 ### 仕様書から実装してPRを作成する（オーケストレーション）
 
 ```
 > 仕様書から実装 --issue 42
 > 実装を開始 --spec .specs/auth-feature/
 > 実装を再開 --resume
+```
+
+### 仕様からPRまでパイプライン全体を1コマンドで回す
+
+```
+> /spec-orchestrate --mode manual          # 対話で仕様を固め、承認したらあとは任せる
+> /spec-orchestrate --issue 42             # auto: Issue を渡して PR を待つ
+> /spec-orchestrate --resume               # 中断した実行を pipeline-state.json から再開
 ```
 
 ### 会話をフォークする（cmux）
@@ -172,6 +188,14 @@ npx skills add anyoneanderson/agent-skills --skill harness-loop -g -y
 > この diff をセカンドオピニオンして
 > 仕様書のセカンドオピニオンをもらって
 > 自由にレビューしてもらって
+```
+
+### ヘッドレスで委譲・レビューする — cmux 不要（agent-delegate）
+
+```
+> このタスクを Codex に投げて
+> Codex にこの diff をレビューさせて
+> cmux なしでセカンドオピニオン
 ```
 
 ### ベストプラクティススキルを提案する
@@ -236,34 +260,57 @@ npx skills add anyoneanderson/agent-skills --skill harness-loop -g -y
    - 既存のテストパターンとフレームワークを検出
    - 結果を `test-{task-id}.md` に出力
 
-10. **spec-implement** がパイプライン全体をオーケストレーション（自分ではコードもレビューも書かない）:
-   - 委任: spec-code → spec-review → fix loop → spec-test
-   - `[code]` フェーズはワーカースキルに委任、`[orchestrator]` フェーズは直接実行
-   - review + test 両方 PASS 後にのみ tasks.md を更新
-   - オプション: **cmux dispatch** でサブエージェント並列実行
-   - 品質ゲート通過後にPRを作成
+10. **spec-evaluate** が受け入れテスト計画（`test.md`）を実装済み機能に対して実行:
+    - 各項目を検証方法別（playwright / command / file-check）に実行
+    - 証跡（スクリーンショット・ログ）を `.specs/{feature}/evidence/{round}/` に保存
+    - 証跡を機械検証: 裏づけファイルのない PASS 報告は FAIL に倒す
+    - `evaluate-{round}.md` を出力 — spec-review 互換 findings として `spec-code --feedback` に渡せる
+
+11. **spec-implement** がパイプライン全体をオーケストレーション（自分ではコードもレビューも書かない）:
+    - 委任: spec-code → spec-review → fix loop → spec-test
+    - `[code]` フェーズはワーカースキルに委任、`[orchestrator]` フェーズは直接実行
+    - review + test 両方 PASS 後にのみ tasks.md を更新
+    - オプション: `--roles` でタスクの `kind:` ラベルごとに Claude（spec-code）/ Codex（agent-delegate）へ振り分け。レビューは常に実装担当の反対側
+    - オプション: **cmux dispatch** でサブエージェント並列実行
+    - 品質ゲート通過後にPRを作成
+
+12. **spec-orchestrate** が要求や Issue から PR までパイプライン全体を駆動:
+    - フェーズ: 受付 → 仕様生成 → 機械検査 → 敵対的仕様レビュー（別 LLM）→ 人間承認（manual のみ）→ 実装 → 受け入れ試験 → PR → 振り返り
+    - 2モード: `manual`（仕様承認の1箇所だけ人間ゲート）と `auto`（Issue を入れると PR が出る、人間の入力なし）
+    - フェーズ別の担当割りを `.specs/pipeline.yml` で設定（claude ⇄ codex）。codex 担当は agent-delegate 経由で実行
+    - 停滞したレビューループを機械シグナル（findings 指紋）で検知し裁定: 担当を入れ替えるか draft PR で着地
+    - 状態は `pipeline-state.json` に保存。中断しても最後の完了フェーズから再開
+    - 振り返りでは実行記録を集計して改善提案を生成し、安全なものは自動適用（ブランチ → PR → 自動マージ。公開契約と SKILL.md は常に人間レビュー）
+
+### エージェント間委譲（cmux 不要）
+
+13. **agent-delegate** がもう一方のエージェント（Claude Code ⇄ Codex）へのタスク委譲・敵対的レビューをヘッドレスで実行:
+    - `--mode delegate` は peer CLI でタスクを実行、`--mode review` は read-only の敵対的レビュー
+    - 機械可読な `report.json` を返す（stdout の最終行が常にそのパス）
+    - 長時間タスクは `--detach` で切り離し、report ファイルをポーリング
+    - `--resume <thread_id>` でセッション継続 — 多ラウンドのレビューを1つの文脈で回せる
 
 ### cmux スキル（オプション、[cmux](https://cmux.dev/) が必要）
 
-11. **cmux-fork** が現在の会話を新しい cmux ペインまたはワークスペースにフォーク。会話コンテキストを完全に引き継ぎ。
+14. **cmux-fork** が現在の会話を新しい cmux ペインまたはワークスペースにフォーク。会話コンテキストを完全に引き継ぎ。
 
-12. **cmux-delegate** が別の cmux ワークスペースに AI エージェントを起動し、タスクを送信・監視・結果回収。Claude Code / Codex / Gemini CLI 対応。
+15. **cmux-delegate** が別の cmux ワークスペースに AI エージェントを起動し、タスクを送信・監視・結果回収。Claude Code / Codex / Gemini CLI 対応。
 
-13. **cmux-second-opinion** が別の AI エージェントに独立したレビューを依頼。親と異なるエージェントを自動選択。コードレビュー・仕様書レビュー対応、基準モード3種。
+16. **cmux-second-opinion** が別の AI エージェントに独立したレビューを依頼。親と異なるエージェントを自動選択。コードレビュー・仕様書レビュー対応、基準モード3種。
 
 ### プロジェクトセットアップ
 
-14. **skill-suggest** がプロジェクトのマニフェストファイル（package.json, Cargo.toml 等）を解析し、skills.sh レジストリからベストプラクティス系スキルを検索・提案・インストール。`--agent` オプションで不要ディレクトリの生成を防止。
+17. **skill-suggest** がプロジェクトのマニフェストファイル（package.json, Cargo.toml 等）を解析し、skills.sh レジストリからベストプラクティス系スキルを検索・提案・インストール。`--agent` オプションで不要ディレクトリの生成を防止。
 
 ### Harness Engineering（自律、オプション）
 
 上記 `/spec-*` フローより一歩進んだ自律レーン。**前提:** 先に **spec-rules-init** と **spec-workflow-init** を実行 — harness は `docs/coding-rules.md` / `docs/review_rules.md` / `docs/issue-to-pr-workflow.md` を、自律エージェントが従う rulebook として消費する。`/spec-*` が人間をタスク単位でループ内に残すのに対し、harness は人間が決めた境界内で sprint まるごとを自走させる。
 
-15. **harness-init** が制御ループを導入: 環境設定を一度ヒアリングし、Planner/Generator/Evaluator サブエージェント・hooks・ガードスクリプト・`.harness/` resilience ツリーを生成。プロジェクトごとに一度実行。
+18. **harness-init** が制御ループを導入: 環境設定を一度ヒアリングし、Planner/Generator/Evaluator サブエージェント・hooks・ガードスクリプト・`.harness/` resilience ツリーを生成。プロジェクトごとに一度実行。
 
-16. **harness-plan** が epic を計画: `product-spec.md` を起草し、sprint 分解/bundling 付きの `roadmap.md` を導出、sprint ごとに tracker Issue を起票。自律実行前の最後の人間介入ステップ。
+19. **harness-plan** が epic を計画: `product-spec.md` を起草し、sprint 分解/bundling 付きの `roadmap.md` を導出、sprint ごとに tracker Issue を起票。自律実行前の最後の人間介入ステップ。
 
-17. **harness-loop** が GAN 制御ループを実行: sprint ごとに contract を交渉し、Generator ⇄ Evaluator を rubric 収束（または Principal Skinner 停止）まで反復、毎 iteration で checkpoint（`progress.md` + `_state.json` + git + `metrics.jsonl`）し PR を作成。モード: interactive / continuous / autonomous-ralph / scheduled。
+20. **harness-loop** が GAN 制御ループを実行: sprint ごとに contract を交渉し、Generator ⇄ Evaluator を rubric 収束（または Principal Skinner 停止）まで反復、毎 iteration で checkpoint（`progress.md` + `_state.json` + git + `metrics.jsonl`）し PR を作成。モード: interactive / continuous / autonomous-ralph / scheduled。
 
 ## 互換性
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npx skills add anyoneanderson/agent-skills --skill spec-orchestrate -g -y
 npx skills add anyoneanderson/agent-skills --skill cmux-fork -g -y
 npx skills add anyoneanderson/agent-skills --skill cmux-delegate -g -y
 npx skills add anyoneanderson/agent-skills --skill cmux-second-opinion -g -y
+npx skills add anyoneanderson/agent-skills --skill agent-delegate -g -y
 npx skills add anyoneanderson/agent-skills --skill skill-suggest -g -y
 
 # Harness Engineering (autonomous) — install spec-rules-init + spec-workflow-init first
@@ -142,12 +143,27 @@ npx skills add anyoneanderson/agent-skills --skill harness-loop -g -y
 > /spec-test --task T-003 --spec .specs/auth-feature/
 ```
 
+### Run acceptance tests against the build
+
+```
+> /spec-evaluate --spec .specs/auth-feature/
+> /spec-evaluate --spec .specs/auth-feature/ --round 2 --backend self
+```
+
 ### Orchestrate full implementation to PR
 
 ```
 > Implement from spec --issue 42
 > Start implementation --spec .specs/auth-feature/
 > Resume implementation --resume
+```
+
+### Run the whole pipeline — spec to PR in one command
+
+```
+> /spec-orchestrate --mode manual          # talk through the spec, approve once, walk away
+> /spec-orchestrate --issue 42             # auto: hand over an Issue, come back to a PR
+> /spec-orchestrate --resume               # continue an interrupted run from pipeline-state.json
 ```
 
 ### Fork a conversation (cmux)
@@ -172,6 +188,14 @@ npx skills add anyoneanderson/agent-skills --skill harness-loop -g -y
 > Get a second opinion on this diff
 > Have another AI review the specs
 > Second opinion, freely review
+```
+
+### Delegate or review headlessly — no cmux needed (agent-delegate)
+
+```
+> Delegate this task to Codex
+> Have Codex review this diff
+> Second opinion without cmux
 ```
 
 ### Suggest best practice skills
@@ -234,34 +258,57 @@ npx skills add anyoneanderson/agent-skills --skill harness-loop -g -y
    - Detects existing test patterns and frameworks
    - Outputs results to `test-{task-id}.md`
 
-9. **spec-implement** orchestrates the full pipeline (does NOT write code or review itself):
-   - Delegates: spec-code → spec-review → fix loop → spec-test
-   - Processes `[code]` phases via worker skills, `[orchestrator]` phases directly
-   - Updates tasks.md ONLY after review AND test PASS
-   - Optional: **cmux dispatch** for parallel sub-agent execution
-   - Creates PR with quality gates passed
+9. **spec-evaluate** runs the acceptance test plan (`test.md`) against the built feature:
+   - Executes each case by its verification method (playwright / command / file-check)
+   - Saves evidence (screenshots, logs) under `.specs/{feature}/evidence/{round}/`
+   - Machine-verifies evidence: a reported PASS with no backing file is forced to FAIL
+   - Outputs `evaluate-{round}.md` — spec-review-compatible findings that feed `spec-code --feedback`
+
+10. **spec-implement** orchestrates the full pipeline (does NOT write code or review itself):
+    - Delegates: spec-code → spec-review → fix loop → spec-test
+    - Processes `[code]` phases via worker skills, `[orchestrator]` phases directly
+    - Updates tasks.md ONLY after review AND test PASS
+    - Optional: `--roles` routes tasks per `kind:` label to Claude (spec-code) or Codex (agent-delegate), with the reviewer always on the opposite side of the implementer
+    - Optional: **cmux dispatch** for parallel sub-agent execution
+    - Creates PR with quality gates passed
+
+11. **spec-orchestrate** drives the entire pipeline from a request or Issue to a PR:
+    - Phases: intake → spec generation → mechanical inspection → adversarial spec review (another LLM) → human approval (manual mode only) → implementation → acceptance testing → PR → retrospective
+    - Two modes: `manual` (one human gate at spec approval) and `auto` (Issue in, PR out, no human input)
+    - Role assignment per phase via `.specs/pipeline.yml` (claude ⇄ codex), executed through agent-delegate
+    - Detects stalled review loops by machine signals (finding fingerprints) and adjudicates: swap roles or land a draft PR
+    - State lives in `pipeline-state.json`; interrupted runs resume from the last completed phase
+    - Retrospective aggregates run records into improvement proposals and can auto-apply safe ones (branch → PR → auto-merge; contracts and SKILL.md always require human review)
+
+### Cross-Agent Delegation (no cmux required)
+
+12. **agent-delegate** hands a task to the other agent (Claude Code ⇄ Codex) headlessly, or gets an adversarial review from it:
+    - `--mode delegate` executes a task on the peer CLI; `--mode review` gets a read-only adversarial review
+    - Returns a machine-readable `report.json` (last line of stdout is always its path)
+    - `--detach` for long runs: poll the report file instead of holding the session
+    - Session continuation via `--resume <thread_id>` keeps multi-round reviews in one context
 
 ### cmux Skills (optional, requires [cmux](https://cmux.dev/))
 
-10. **cmux-fork** forks the current conversation into a new cmux pane or workspace, preserving full context.
+13. **cmux-fork** forks the current conversation into a new cmux pane or workspace, preserving full context.
 
-11. **cmux-delegate** launches an AI agent in a separate cmux workspace, sends a task, monitors completion, and collects results. Supports Claude Code, Codex, Gemini CLI.
+14. **cmux-delegate** launches an AI agent in a separate cmux workspace, sends a task, monitors completion, and collects results. Supports Claude Code, Codex, Gemini CLI.
 
-12. **cmux-second-opinion** gets an independent review from a different AI agent. Automatically selects an agent different from the parent. Supports code review and spec review with 3 criteria modes.
+15. **cmux-second-opinion** gets an independent review from a different AI agent. Automatically selects an agent different from the parent. Supports code review and spec review with 3 criteria modes.
 
 ### Project Setup
 
-13. **skill-suggest** analyzes the project's manifest files (package.json, Cargo.toml, etc.), searches the skills.sh registry for matching best-practice skills, and installs them with agent-targeted installation to prevent unwanted directory creation.
+16. **skill-suggest** analyzes the project's manifest files (package.json, Cargo.toml, etc.), searches the skills.sh registry for matching best-practice skills, and installs them with agent-targeted installation to prevent unwanted directory creation.
 
 ### Harness Engineering (autonomous, optional)
 
 A separate, more autonomous lane than the `/spec-*` flow above. **Prerequisite:** run **spec-rules-init** and **spec-workflow-init** first — harness consumes `docs/coding-rules.md`, `docs/review_rules.md`, and `docs/issue-to-pr-workflow.md` as the rulebook its autonomous agents obey. Where `/spec-*` keeps a human in the loop task-by-task, harness drives whole sprints on its own inside human-set boundaries.
 
-14. **harness-init** installs the control loop: hears environment settings once, then generates Planner/Generator/Evaluator sub-agents, hooks, guard scripts, and the `.harness/` resilience tree. Run once per project.
+17. **harness-init** installs the control loop: hears environment settings once, then generates Planner/Generator/Evaluator sub-agents, hooks, guard scripts, and the `.harness/` resilience tree. Run once per project.
 
-15. **harness-plan** plans an epic: drafts `product-spec.md`, derives `roadmap.md` with sprint decomposition/bundling, and emits one tracker Issue per sprint. The last human-in-the-loop step before autonomous execution.
+18. **harness-plan** plans an epic: drafts `product-spec.md`, derives `roadmap.md` with sprint decomposition/bundling, and emits one tracker Issue per sprint. The last human-in-the-loop step before autonomous execution.
 
-16. **harness-loop** runs the GAN control loop: per sprint it negotiates the contract, iterates Generator ⇄ Evaluator to rubric convergence (or a Principal Skinner stop), checkpoints every iteration (`progress.md` + `_state.json` + git + `metrics.jsonl`), and opens the PR. Modes: interactive / continuous / autonomous-ralph / scheduled.
+19. **harness-loop** runs the GAN control loop: per sprint it negotiates the contract, iterates Generator ⇄ Evaluator to rubric convergence (or a Principal Skinner stop), checkpoints every iteration (`progress.md` + `_state.json` + git + `metrics.jsonl`), and opens the PR. Modes: interactive / continuous / autonomous-ralph / scheduled.
 
 ## Compatibility
 


### PR DESCRIPTION
## 概要
- PR #68 で追加・拡張したスキルのうち、README のスキルテーブルにしか載っていなかった3スキル（spec-evaluate / spec-orchestrate / agent-delegate）の使い方を Quick Start と How It Works に追記します。
- agent-delegate はインストールコマンドの一覧からも漏れていたため追加します。
- spec-implement の説明に kind ルーティング（--roles）の1行を追加し、番号を振り直しています。README.md / README.ja.md 両方対応です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)