### PR TITLE
fix(agent-delegate): owner lock中のsignalで終端結果を失わない

### DIFF
--- a/skills/agent-delegate/references/scripts/agent-delegate.sh
+++ b/skills/agent-delegate/references/scripts/agent-delegate.sh
@@ -86,6 +86,13 @@ MONITOR_HEARTBEAT_PID=""
 REPORT_IS_CANDIDATE=0
 REPORT_PUBLISH_ONLY_IF_ABSENT=0
 RUN_CLI_APPEND_STDERR=0
+OWNER_LOCK_HELD=0
+OWNER_LOCK_SIGNAL_GUARD_ACTIVE=0
+OWNER_LOCK_PENDING_SIGNAL=""
+OWNER_LOCK_SAVED_TERM=""
+OWNER_LOCK_SAVED_INT=""
+OWNER_LOCK_SAVED_HUP=""
+OWNER_LOCK_TEST_SIGNAL_SENT=0
 
 # Sandbox flag outputs (resolve_sandbox_flags()).
 CODEX_SANDBOX_VALUE=""
@@ -239,6 +246,23 @@ compute_paths() {
 utc_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 heartbeat_test_mode() { [ "${AGENT_DELEGATE_TEST_MODE:-0}" = heartbeat ]; }
+owner_lock_signal_test_mode() { [ "${AGENT_DELEGATE_TEST_MODE:-0}" = owner-lock-signal ]; }
+
+owner_lock_signal_test_hook() {
+  local stage="$1" configured="${AGENT_DELEGATE_TEST_OWNER_LOCK_SIGNAL_STAGE:-}"
+  local ready_file="${AGENT_DELEGATE_TEST_OWNER_LOCK_READY_FILE:-}" deadline
+  owner_lock_signal_test_mode || return 0
+  [ "$OWNER_LOCK_TEST_SIGNAL_SENT" -eq 0 ] && [ "$configured" = "$stage" ] || return 0
+  if [ -n "$ready_file" ]; then
+    deadline=$((SECONDS + 5))
+    while [ ! -f "$ready_file" ]; do
+      [ "$SECONDS" -lt "$deadline" ] || { err "owner lock signal test readiness timeout"; return 1; }
+      sleep 0.01
+    done
+  fi
+  OWNER_LOCK_TEST_SIGNAL_SENT=1
+  kill -TERM "${BASHPID:-$$}"
+}
 
 heartbeat_test_evidence_json() {
   local suffix="$1" path tmp
@@ -297,10 +321,55 @@ process_probe() {
   fi
 }
 
-OWNER_LOCK_HELD=0
+owner_lock_capture_signal() {
+  local signal="$1"
+  [ -n "$OWNER_LOCK_PENDING_SIGNAL" ] || OWNER_LOCK_PENDING_SIGNAL="$signal"
+}
+
+owner_lock_restore_signal_trap() {
+  local saved="$1" signal="$2"
+  if [ -n "$saved" ]; then eval "$saved"; else trap - "$signal"; fi
+}
+
+owner_lock_signal_guard_enter() {
+  if [ "$OWNER_LOCK_SIGNAL_GUARD_ACTIVE" -eq 1 ]; then
+    err "nested owner lock signal guard"
+    return 1
+  fi
+  OWNER_LOCK_PENDING_SIGNAL=""
+  OWNER_LOCK_SAVED_TERM="$(trap -p TERM)"
+  OWNER_LOCK_SAVED_INT="$(trap -p INT)"
+  OWNER_LOCK_SAVED_HUP="$(trap -p HUP)"
+  OWNER_LOCK_SIGNAL_GUARD_ACTIVE=1
+  trap 'owner_lock_capture_signal TERM' TERM
+  trap 'owner_lock_capture_signal INT' INT
+  trap 'owner_lock_capture_signal HUP' HUP
+}
+
+# Replaying a captured signal only after rmdir prevents a monitor or heartbeat
+# publisher from dying while it owns the mkdir-based lock.
+owner_lock_signal_guard_leave() {
+  local pending saved_term saved_int saved_hup
+  [ "$OWNER_LOCK_SIGNAL_GUARD_ACTIVE" -eq 1 ] || return 0
+  pending="$OWNER_LOCK_PENDING_SIGNAL"
+  saved_term="$OWNER_LOCK_SAVED_TERM"; saved_int="$OWNER_LOCK_SAVED_INT"; saved_hup="$OWNER_LOCK_SAVED_HUP"
+  OWNER_LOCK_SIGNAL_GUARD_ACTIVE=0
+  OWNER_LOCK_PENDING_SIGNAL=""
+  OWNER_LOCK_SAVED_TERM=""; OWNER_LOCK_SAVED_INT=""; OWNER_LOCK_SAVED_HUP=""
+  owner_lock_restore_signal_trap "$saved_term" TERM
+  owner_lock_restore_signal_trap "$saved_int" INT
+  owner_lock_restore_signal_trap "$saved_hup" HUP
+  [ -z "$pending" ] || kill -s "$pending" "${BASHPID:-$$}" 2>/dev/null || true
+}
+
 acquire_owner_lock() {
   local deadline=$((SECONDS + OWNER_LOCK_TIMEOUT)) holder_pid="" quarantine holder_hash remaining
+  owner_lock_signal_guard_enter || return 1
   while ! mkdir "$OWNER_LOCK" 2>/dev/null; do
+    if [ -n "$OWNER_LOCK_PENDING_SIGNAL" ]; then
+      owner_lock_signal_guard_leave
+      return 130
+    fi
     if [ "$FORCE" -eq 1 ] && [ -r "$OWNER_LOCK/holder" ]; then
       holder_pid="$(awk -F': ' '$1=="pid"{print $2; exit}' "$OWNER_LOCK/holder" 2>/dev/null || true)"
       if [ "$(process_probe "$holder_pid")" = "absent" ]; then
@@ -317,14 +386,21 @@ acquire_owner_lock() {
         fi
       fi
     fi
-    [ "$SECONDS" -lt "$deadline" ] || { err "timed out acquiring owner lock: $OWNER_LOCK"; return 1; }
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      err "timed out acquiring owner lock: $OWNER_LOCK"
+      owner_lock_signal_guard_leave
+      return 1
+    fi
     sleep 0.05
   done
   OWNER_LOCK_HELD=1
-  {
+  if ! {
     printf 'pid: %s\n' "${BASHPID:-$$}"
     printf 'run_id: %s\n' "${RUN_ID:-unknown}"
-  } > "$OWNER_LOCK/holder"
+  } > "$OWNER_LOCK/holder"; then
+    release_owner_lock
+    return 1
+  fi
 }
 
 release_owner_lock() {
@@ -332,6 +408,7 @@ release_owner_lock() {
   rm -f "$OWNER_LOCK/holder"
   rmdir "$OWNER_LOCK" 2>/dev/null || true
   OWNER_LOCK_HELD=0
+  owner_lock_signal_guard_leave
 }
 
 owner_is_valid() {
@@ -1341,7 +1418,9 @@ write_heartbeat() {
        report_path:$report_path}
     ' > "$HEARTBEAT_TMP"
   chmod 600 "$HEARTBEAT_TMP"
+  [ "$state" != running ] || owner_lock_signal_test_hook before_acquire
   acquire_owner_lock || { rm -f "$HEARTBEAT_TMP"; return 1; }
+  [ "$state" != running ] || owner_lock_signal_test_hook lock_held
   if ! owner_matches_run "$RUN_ID" || ! pid_matches_run "$RUN_ID" "$MONITOR_PID"; then
     release_owner_lock
     rm -f "$HEARTBEAT_TMP"
@@ -1369,6 +1448,7 @@ write_heartbeat() {
     return 1
   fi
   release_owner_lock
+  [ "$state" != running ] || owner_lock_signal_test_hook after_publish
 }
 
 heartbeat_loop() {
@@ -1915,6 +1995,19 @@ if [ -n "${AGENT_DELEGATE_TEST_LSTAT_METADATA:-}" ] && [ "${AGENT_DELEGATE_TEST_
   err "AGENT_DELEGATE_TEST_LSTAT_METADATA is only valid in heartbeat test mode"
   exit 2
 fi
+if [ -n "${AGENT_DELEGATE_TEST_OWNER_LOCK_SIGNAL_STAGE:-}" ]; then
+  if ! owner_lock_signal_test_mode; then
+    err "AGENT_DELEGATE_TEST_OWNER_LOCK_SIGNAL_STAGE is only valid in owner lock signal test mode"
+    exit 2
+  fi
+  case "$AGENT_DELEGATE_TEST_OWNER_LOCK_SIGNAL_STAGE" in
+    before_acquire|lock_held|after_publish) : ;;
+    *) err "invalid owner lock signal test stage"; exit 2 ;;
+  esac
+elif owner_lock_signal_test_mode; then
+  err "owner lock signal test mode requires a signal stage"
+  exit 2
+fi
 
 HANDOFF_ROOT="$(cd "${TMPDIR:-/tmp}" && pwd)"
 compute_paths
@@ -1939,7 +2032,7 @@ fi
 if [ "$DETACH" -eq 1 ]; then
   LAUNCHER_PID="${BASHPID:-$$}"
   HANDOFF_DEADLINE=$(( $(date -u +%s) + HANDOFF_TIMEOUT ))
-  if heartbeat_test_mode; then
+  if heartbeat_test_mode || owner_lock_signal_test_mode; then
     HANDOFF_DIR="${AGENT_DELEGATE_TEST_HANDOFF_DIR:-}"
     if [ -z "$HANDOFF_DIR" ] || [ "${HANDOFF_DIR#/}" = "$HANDOFF_DIR" ] ||
        [ ! -d "$HANDOFF_DIR" ] || [ -L "$HANDOFF_DIR" ] ||
@@ -1947,7 +2040,7 @@ if [ "$DETACH" -eq 1 ]; then
        [ "$(stat_uid "$HANDOFF_DIR")" != "$(id -u)" ] ||
        [ "$(stat_mode "$HANDOFF_DIR")" != 700 ] ||
        [ -n "$(find "$HANDOFF_DIR" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null || true)" ]; then
-      err "heartbeat test handoff directory must be an empty mode 0700 directory directly under $HANDOFF_ROOT"
+      err "test handoff directory must be an empty mode 0700 directory directly under $HANDOFF_ROOT"
       exit 2
     fi
   else

--- a/skills/agent-delegate/references/scripts/tests/fixtures/owner-lock-signal-cases.tsv
+++ b/skills/agent-delegate/references/scripts/tests/fixtures/owner-lock-signal-cases.tsv
@@ -1,0 +1,4 @@
+case_id	signal_stage	expected_status
+term-before-lock	before_acquire	blocked
+term-lock-held	lock_held	blocked
+term-after-publish	after_publish	blocked

--- a/skills/agent-delegate/references/scripts/tests/run_tests.sh
+++ b/skills/agent-delegate/references/scripts/tests/run_tests.sh
@@ -556,11 +556,15 @@ process_group_of() {
 
 cleanup_detach_stub_fixture() {
   local dir="$1" label="$2" owner="$dir/$label-owner.json" monitor="" worker="" pgid="" own_pgid
-  local handoff=""
+  local handoff="" heartbeat="$dir/$label-heartbeat.json"
   if [ -f "$owner" ] && jq -e . "$owner" >/dev/null 2>&1; then
     monitor="$(jq -r '.monitor_pid // empty' "$owner")"
     worker="$(jq -r '.worker_pid // empty' "$owner")"
     handoff="$(jq -r '.handoff_dir // empty' "$owner")"
+  fi
+  if [ -z "$monitor" ] && jq -e . "$heartbeat" >/dev/null 2>&1; then
+    monitor="$(jq -r '.monitor_pid // empty' "$heartbeat")"
+    worker="$(jq -r '.pid // empty' "$heartbeat")"
   fi
   own_pgid="$(process_group_of "${BASHPID:-$$}")"
   if [ -n "$monitor" ]; then
@@ -577,12 +581,21 @@ cleanup_detach_stub_fixture() {
 }
 
 launch_detach_review_stub() {
-  local dir="$1" label="$2" barrier="$3" driver driver_pgid monitor_mode=0
+  local dir="$1" label="$2" barrier="$3" signal_stage="${4:-}" test_handoff="${5:-}"
+  local driver driver_pgid monitor_mode=0 test_mode=0 ready_file=""
+  if [ -n "$signal_stage" ]; then
+    test_mode=owner-lock-signal
+    ready_file="$barrier/claude.ready"
+  fi
   case $- in *m*) monitor_mode=1 ;; esac
   set -m
   (
     exec env PATH="$STUB_DIR:$PATH" AGENT_DELEGATE_STUB_BARRIER_DIR="$barrier" \
-      AGENT_DELEGATE_STUB_REVIEW=1 bash "$SCRIPT" --mode review --prompt-file "$dir/prompt.md" \
+      AGENT_DELEGATE_STUB_REVIEW=1 AGENT_DELEGATE_TEST_MODE="$test_mode" \
+      AGENT_DELEGATE_TEST_HANDOFF_DIR="$test_handoff" \
+      AGENT_DELEGATE_TEST_OWNER_LOCK_SIGNAL_STAGE="$signal_stage" \
+      AGENT_DELEGATE_TEST_OWNER_LOCK_READY_FILE="$ready_file" \
+      bash "$SCRIPT" --mode review --prompt-file "$dir/prompt.md" \
         --out-dir "$dir" --label "$label" --target claude --detach
   ) > "$dir/$label-launch.out" 2> "$dir/$label-launch.err" &
   driver=$!
@@ -669,6 +682,63 @@ run_detach_review_lifecycle_stub() (
   rm -rf "$dir"
 )
 
+check_owner_lock_signal_artifacts() {
+  local report="$1" heartbeat="$2" dir="$3" label="$4" handoff="$5" expected_status="$6"
+  [ -f "$report" ] && [ -f "$heartbeat" ] || return 1
+  jq -e --arg status "$expected_status" '
+    .status==$status and (.meta.run_id|type)=="string" and (.meta.run_id|length)>0 and
+    .blocker_category=="env_error" and (.blocker|contains("TERM"))
+  ' "$report" >/dev/null || return 1
+  jq -e --arg status "$expected_status" --slurpfile report "$report" '
+    .state==$status and .run_id==$report[0].meta.run_id and
+    (.pid|type)=="number" and (.monitor_pid|type)=="number"
+  ' "$heartbeat" >/dev/null || return 1
+  [ ! -e "$dir/$label-owner.json" ] && [ ! -e "$dir/$label.pid" ] &&
+    [ ! -e "$dir/$label-owner.lock" ] && [ ! -d "$handoff" ] || return 1
+  ! find "$dir" -maxdepth 1 \( -name "$label-report.candidate.*" -o -name "$label-report.json.tmp.*" \
+    -o -name "$label-heartbeat.json.tmp.*" -o -name "$label-owner.json.tmp.*" \) -print -quit | grep -q .
+}
+
+run_owner_lock_signal_stub() (
+  local case_id="$1" signal_stage="$2" expected_status="$3" dir label barrier handoff report heartbeat bad_heartbeat
+  local monitor peer deadline
+  dir="$(new_work_dir)"; label="owner-lock-signal-$case_id"; barrier="$dir/barrier"
+  handoff="$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd)/agent-delegate-owner-lock-signal-handoff.XXXXXX")"
+  chmod 700 "$handoff"
+  trap 'cleanup_detach_stub_fixture "$dir" "$label"; rm -rf "$handoff"' EXIT TERM INT HUP
+  mkdir "$barrier"; mkfifo "$barrier/release.fifo"; printf 'review prompt\n' > "$dir/prompt.md"
+  launch_detach_review_stub "$dir" "$label" "$barrier" "$signal_stage" "$handoff" || return 1
+  report="$dir/$label-report.json"; heartbeat="$dir/$label-heartbeat.json"
+  deadline=$(( $(date -u +%s) + 10 ))
+  while [ "$(date -u +%s)" -lt "$deadline" ]; do
+    if check_owner_lock_signal_artifacts "$report" "$heartbeat" "$dir" "$label" "$handoff" "$expected_status"; then
+      monitor="$(jq -r '.monitor_pid' "$heartbeat")"
+      peer="$(cat "$barrier/claude.pid" 2>/dev/null || true)"
+      if ! kill -0 "$monitor" 2>/dev/null && { [ -z "$peer" ] || ! kill -0 "$peer" 2>/dev/null; }; then break; fi
+    fi
+  done
+  check_owner_lock_signal_artifacts "$report" "$heartbeat" "$dir" "$label" "$handoff" "$expected_status" || return 1
+  monitor="$(jq -r '.monitor_pid' "$heartbeat")"; ! kill -0 "$monitor" 2>/dev/null || return 1
+  peer="$(cat "$barrier/claude.pid" 2>/dev/null || true)"; [ -z "$peer" ] || ! kill -0 "$peer" 2>/dev/null || return 1
+
+  bad_heartbeat="$dir/$label-heartbeat.negative.json"
+  jq '.run_id="corrupted-run"' "$heartbeat" > "$bad_heartbeat"
+  if check_owner_lock_signal_artifacts "$report" "$bad_heartbeat" "$dir" "$label" "$handoff" "$expected_status"; then
+    return 1
+  fi
+  rm -f "$bad_heartbeat"
+  trap - EXIT TERM INT HUP
+  rm -rf "$dir"
+)
+
+check_owner_lock_signal_fixture() {
+  local file="$1" case_id signal_stage expected_status
+  while IFS=$'\t' read -r case_id signal_stage expected_status; do
+    [ "$case_id" = case_id ] && continue
+    run_owner_lock_signal_stub "$case_id" "$signal_stage" "$expected_status" || return 1
+  done < "$file"
+}
+
 case_clean_checkout_compatibility() {
   local dir rc worktree_parent worktree runner_rel deadline detach_report bad_fixture
   runner_rel="skills/agent-delegate/references/scripts/tests/run_tests.sh"
@@ -719,6 +789,8 @@ case_clean_checkout_compatibility() {
   run_detach_review_lifecycle_stub survives-launcher-exit || die "detach monitor did not survive launcher process-group cleanup"
   run_detach_review_lifecycle_stub worker-death || die "detach monitor did not synthesize blocked after worker death"
   run_detach_review_lifecycle_stub monitor-termination || die "detach monitor did not synthesize blocked after monitor termination"
+  check_owner_lock_signal_fixture "$FIXTURE_DIR/owner-lock-signal-cases.tsv" ||
+    die "owner lock signal fixture rejected"
 }
 
 case_monitor_only_publishers() {


### PR DESCRIPTION
## 概要

owner lockの保持中にmonitorまたはheartbeat publisherがTERMを受けても、lock directoryを削除してからsignal処理を再開できるようにします。
従来はsignalが臨界区間へ割り込むとlock directoryが残り、blocked reportとterminal heartbeatの公開処理も同じlockで停止していました。

Closes #98

## 変更内容

- owner lockを取得する前に現在のTERM、INT、HUP trapを保存し、臨界区間では最初に受けたsignalを記録します。
- publisherがlock directoryを削除した後、保存したtrapを戻してから記録済みのsignalを自分へ再送します。
- signalを無視せず遅延して再送するため、monitorは既存の異常終了処理を実行し、blocked reportとterminal heartbeatを公開できます。
- lock取得待ちでsignalを受けた場合もtrapを戻し、lockを取得しないままsignal処理へ移ります。
- テスト専用の一回限りのTERM注入を追加し、通常実行では利用できないように実行モードと段階を検証します。

## 実ファイルシステム検証

tracked harnessはinitial heartbeatの公開処理へ、次の3段階でTERMを送ります。

- owner lock取得前
- owner lock保持中
- running heartbeat公開後

各段階で、blocked reportとterminal heartbeatのrun IDが一致することを確認します。
owner、pid、FIFO、handoff directory、report candidate、一時ファイル、lock directoryが残らないことも検査します。
heartbeatのrun IDを変更したnegativeデータは同じ検査で不合格になります。

## 対象外

stale ownerの一般回収、同期runの衝突、孤児化したpeer CLI、stale reaperの追加改善は変更していません。
これらは親Issue #92の対象です。

## 検証

- `bash -n skills/agent-delegate/references/scripts/agent-delegate.sh skills/agent-delegate/references/scripts/tests/run_tests.sh`
- `git diff --check`
- `AGENT_DELEGATE_IN_CLEAN_CHECKOUT=1 bash skills/agent-delegate/references/scripts/tests/run_tests.sh --case clean-checkout-compatibility`
- `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --case heartbeat-schema-and-pids`
- `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --case run-ownership-force-resume`
- `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --case synchronous-no-heartbeat`
- `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --case pid-handoff-barrier`
- `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --all --repeat 3`
  - commit後のdetached clean checkoutで今回の3段階signal testを各回実行しました。
  - 3回とも22ケース中22ケースがPASSしました。
  - T-A17が参照するGit管理外の既存仕様4ファイルは、検証中だけ元worktreeからsymlinkで参照しました。
