### PR TITLE
fix(agent-delegate): 異常終了時のcleanupを強化する (closes #92)

### DIFF
--- a/skills/agent-delegate/references/contract.ja.md
+++ b/skills/agent-delegate/references/contract.ja.md
@@ -203,12 +203,22 @@ heartbeat を公開するたびに、monitor は同じ owner lock 区間で `lea
 launcher は owner と pid の run id と monitor PID が一致した後にだけ、owner の `run_id` を expected run として採用する。
 launcher はその値を出力し、呼び出し側は sentinel から expected run を導出しない。
 
-同じ label の次回起動では、preflight stale-reaper が放棄済みの handoff を検査する。
-owner と pid が同じ不在 monitor を指し、lease が90秒より古い場合に限り削除候補とする。
-handoff のパスは設定 root の直下にある非 symlink の mode 0700 ディレクトリであり、実行ユーザーが所有し、basename の launcher PID と device/inode が検査中に変わらないことを要求する。
+同じ label の次回起動では、preflight stale-reaper が、形式が正しく、lease の更新から90秒を超えた owner を検査する。
+sync owner は、`monitor_pid` と `handoff_dir` が null、runner、launcher、worker の PID が一致、pid ファイルのパスが不在、runner のプロセスが不在という条件をすべて満たす場合に限り削除する。
+
+detach owner では monitor が不在でなければならず、pid ファイルのパスが残っている場合は run id と monitor PID も owner と一致しなければならない。
+handoff ディレクトリがすでに消失している場合、stale-reaper は保存済みパスが設定 root の直下にある絶対パスで、basename に想定する launcher PID が含まれることを確認してから、owner と残っている pid record を削除する。
+handoff ディレクトリが残っている場合、実行ユーザーが所有する非 symlink の mode 0700 のディレクトリであり、検査中に device と inode が変わらないことを要求する。
 sentinel があれば JSON の識別情報も一致しなければならない。
-列挙済みの FIFO、一致する一時ファイル、sentinel だけを削除でき、未知の項目や不一致があれば保持して診断を残す。
+stale-reaper が削除できるのは、列挙済みの FIFO、一致する一時ファイル、sentinel だけである。
+未知の項目や識別情報の不一致があれば handoff ディレクトリを残し、診断を出力する。
+
+stale な detach owner を `--force` で引き継ぐ場合、stale-reaper は owner を削除する前に旧 monitor のプロセスグループを停止する。
+保存済み monitor PID が現在のプロセスグループと異なり、旧プロセスグループに `agent-delegate`、`codex`、`claude` のいずれかが残っている場合に限り、プロセスグループへシグナルを送る。
+stale-reaper は `TERM` を送り、最大1秒待ってもプロセスグループが残っていれば `KILL` を送る。
 terminal report と terminal heartbeat は残す。
+
+stale-reaper が期限内に owner lock を取得できない場合、新しい run は peer を起動せず exit 2 で終了し、`report.json` を書かない。
 
 ## review モード
 

--- a/skills/agent-delegate/references/contract.md
+++ b/skills/agent-delegate/references/contract.md
@@ -216,15 +216,31 @@ The launcher accepts the owner's `run_id` as the expected run only after owner
 and pid contain that same run id and monitor PID. It prints that value; callers
 must not derive the expected run from the sentinel.
 
-On the next launch for the same label, the preflight stale reaper removes an
-abandoned handoff only when the owner and pid identify the same absent monitor,
-the lease is more than 90 seconds old, and the handoff path is a non-symlink
-mode-0700 directory owned by the current user directly below the configured
-root with the expected launcher-PID basename and unchanged device/inode.
-When a sentinel exists, its JSON identity must also match. Only enumerated
-FIFOs, matching temporary files, and the sentinel may be removed; unknown or
-mismatched content is retained and diagnosed rather than removed. The terminal
-report and terminal heartbeat are retained.
+On the next launch for the same label, the preflight stale reaper examines a
+valid owner whose lease is more than 90 seconds old. A synchronous owner is
+removed only when it has the required null monitor and handoff fields, its
+runner, launcher, and worker PIDs are identical, no pid path exists, and the
+runner process is absent.
+
+A detached owner requires an absent monitor and, when the pid path exists, a
+matching run id and monitor PID. If the handoff directory is already absent,
+the reaper validates that the stored absolute path is directly below the
+configured root and that its basename contains the expected launcher PID before
+removing the owner and optional pid record. An existing handoff must be a
+non-symlink mode-0700 directory owned by the current user with an unchanged
+device/inode. When a sentinel exists, its JSON identity must also match. Only
+enumerated FIFOs, matching temporary files, and the sentinel may be removed;
+unknown or mismatched content is retained and diagnosed rather than removed.
+
+During a `--force` takeover of a stale detached owner, the reaper stops the old
+monitor process group before removing its owner record. It signals the group
+only when the stored monitor PID differs from the current process group and the
+group still contains an `agent-delegate`, `codex`, or `claude` process. The
+reaper sends `TERM`, waits up to one second, then sends `KILL` if the group still
+exists. The terminal report and terminal heartbeat are retained.
+
+If the stale reaper cannot acquire the owner lock within its timeout, the new
+launch exits 2 before starting a peer and does not write `report.json`.
 
 ## Review mode
 

--- a/skills/agent-delegate/references/scripts/agent-delegate.sh
+++ b/skills/agent-delegate/references/scripts/agent-delegate.sh
@@ -566,6 +566,36 @@ terminate_confirmed_old_process() {
   kill -KILL "$pid" 2>/dev/null || true
 }
 
+terminate_confirmed_old_monitor_group() {
+  local monitor_pid="$1" pid pgid command current_pgid="" confirmed=0 i
+  case "$monitor_pid" in ''|*[!0-9]*|0) return 0 ;; esac
+  current_pgid="$(ps -o pgid= -p "${BASHPID:-$$}" 2>/dev/null | tr -d '[:space:]')"
+  [ "$monitor_pid" != "$current_pgid" ] || return 0
+
+  # Detached monitors are launched as process-group leaders. If the monitor and
+  # worker die first, the peer CLI can remain in that group without a PID in the
+  # owner record. Confirm that the group still contains an agent-delegate or peer
+  # process before signalling the whole group, so a recycled PID cannot target an
+  # unrelated process group.
+  while read -r pid pgid command; do
+    [ "$pgid" = "$monitor_pid" ] || continue
+    if [[ "$command" == *"$(basename "$SELF")"*"--_monitor"* ]] ||
+       [[ "$command" == *"$(basename "$SELF")"*"--_worker"* ]] ||
+       [[ "$command" =~ (^|[[:space:]/])(codex|claude)([[:space:]]|$) ]]; then
+      confirmed=1
+      break
+    fi
+  done < <(ps -axo pid=,pgid=,command= 2>/dev/null)
+  [ "$confirmed" -eq 1 ] || return 0
+
+  kill -TERM -- "-$monitor_pid" 2>/dev/null || return 0
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 -- "-$monitor_pid" 2>/dev/null || return 0
+    sleep 0.1
+  done
+  kill -KILL -- "-$monitor_pid" 2>/dev/null || true
+}
+
 publish_detach_owner() {
   local monitor_pid="$1" started_at="$2" pid_tmp="${PID_FILE}.tmp.${RUN_ID}"
   local pid_backup="${PID_FILE}.backup.${RUN_ID}"
@@ -648,6 +678,7 @@ publish_detach_owner() {
   remove_run_artifacts "$old_run_id"
   release_owner_lock
   if [ "$FORCE" -eq 1 ]; then
+    terminate_confirmed_old_monitor_group "$old_monitor_pid"
     terminate_confirmed_old_process "$old_worker_pid" worker
     terminate_confirmed_old_process "$old_monitor_pid" monitor
     [ "$old_runner_pid" = "$old_monitor_pid" ] || terminate_confirmed_old_process "$old_runner_pid" runner
@@ -695,6 +726,7 @@ publish_sync_owner() {
   remove_run_artifacts "$old_run_id"
   release_owner_lock
   if [ "$FORCE" -eq 1 ]; then
+    terminate_confirmed_old_monitor_group "$old_monitor_pid"
     terminate_confirmed_old_process "$old_worker_pid" worker
     terminate_confirmed_old_process "$old_monitor_pid" monitor
     [ "$old_runner_pid" = "$old_monitor_pid" ] || terminate_confirmed_old_process "$old_runner_pid" runner

--- a/skills/agent-delegate/references/scripts/agent-delegate.sh
+++ b/skills/agent-delegate/references/scripts/agent-delegate.sh
@@ -63,6 +63,8 @@ REPORT_FILE=""
 REPORT_TMP=""
 LAST_MSG_FILE=""
 STDOUT_FILE=""
+RUN_LAST_MSG_FILE=""
+RUN_STDOUT_FILE=""
 STDERR_FILE=""
 PID_FILE=""
 REVIEW_FILE=""
@@ -83,6 +85,7 @@ MONITOR_GUARD_ARMED=0
 MONITOR_STARTED_AT=""
 MONITOR_WORKER_PID=""
 MONITOR_HEARTBEAT_PID=""
+MONITOR_SETUP_GUARD_ARMED=0
 REPORT_IS_CANDIDATE=0
 REPORT_PUBLISH_ONLY_IF_ABSENT=0
 RUN_CLI_APPEND_STDERR=0
@@ -227,6 +230,12 @@ compute_paths() {
   REPORT_TMP="${OUT_DIR}/${LABEL}-report.json.tmp.${RUN_ID:-pending}"
   LAST_MSG_FILE="${OUT_DIR}/${LABEL}-last.txt"
   STDOUT_FILE="${OUT_DIR}/${LABEL}-stdout.${stdout_ext}"
+  RUN_LAST_MSG_FILE="$LAST_MSG_FILE"
+  RUN_STDOUT_FILE="$STDOUT_FILE"
+  if [ -n "$RUN_ID" ]; then
+    RUN_LAST_MSG_FILE="${OUT_DIR}/${LABEL}-last.${RUN_ID}.txt"
+    RUN_STDOUT_FILE="${OUT_DIR}/${LABEL}-stdout.${RUN_ID}.${stdout_ext}"
+  fi
   STDERR_FILE="${OUT_DIR}/${LABEL}-stderr.log"
   PID_FILE="${OUT_DIR}/${LABEL}.pid"
   HEARTBEAT_FILE="${OUT_DIR}/${LABEL}-heartbeat.json"
@@ -449,6 +458,32 @@ report_is_terminal_for_run() {
   ' "$file" >/dev/null 2>&1
 }
 
+remove_run_artifacts() {
+  local run_id="$1" stdout_ext="jsonl"
+  [ -n "$run_id" ] || return 0
+  [ "$TARGET" = "claude" ] && stdout_ext="json"
+  rm -f "${OUT_DIR}/${LABEL}-last.${run_id}.txt" \
+    "${OUT_DIR}/${LABEL}-stdout.${run_id}.${stdout_ext}"
+}
+
+publish_run_artifacts() {
+  acquire_owner_lock || return 1
+  if ! owner_matches_run "$RUN_ID"; then
+    release_owner_lock
+    rm -f "$RUN_LAST_MSG_FILE" "$RUN_STDOUT_FILE"
+    return 3
+  fi
+  if [ -e "$RUN_LAST_MSG_FILE" ] && ! mv -f "$RUN_LAST_MSG_FILE" "$LAST_MSG_FILE"; then
+    release_owner_lock
+    return 1
+  fi
+  if [ -e "$RUN_STDOUT_FILE" ] && ! mv -f "$RUN_STDOUT_FILE" "$STDOUT_FILE"; then
+    release_owner_lock
+    return 1
+  fi
+  release_owner_lock
+}
+
 owner_publish_path() {
   local run_id="$1" source="$2" target="$3" require_pid="${4:-0}" monitor_pid="${5:-}"
   acquire_owner_lock || { rm -f "$source"; return 1; }
@@ -535,7 +570,7 @@ publish_detach_owner() {
   local monitor_pid="$1" started_at="$2" pid_tmp="${PID_FILE}.tmp.${RUN_ID}"
   local pid_backup="${PID_FILE}.backup.${RUN_ID}"
   local old_owner_hash old_pid_hash old_report_hash old_heartbeat_hash old_pid_ino=""
-  local old_runner_pid="" old_monitor_pid="" old_worker_pid=""
+  local old_run_id="" old_runner_pid="" old_monitor_pid="" old_worker_pid=""
 
   jq -n \
     --arg run_id "$RUN_ID" --argjson runner_pid "$monitor_pid" \
@@ -568,6 +603,7 @@ publish_detach_owner() {
   old_heartbeat_hash="$(file_hash_or_absent "$HEARTBEAT_FILE")"
   [ ! -e "$PID_FILE" ] || old_pid_ino="$(stat_ino "$PID_FILE")"
   if owner_is_valid "$OWNER_FILE"; then
+    old_run_id="$(jq -r '.run_id' "$OWNER_FILE")"
     old_runner_pid="$(jq -r '.runner_pid // empty' "$OWNER_FILE")"
     old_monitor_pid="$(jq -r '.monitor_pid // empty' "$OWNER_FILE")"
     old_worker_pid="$(jq -r '.worker_pid // empty' "$OWNER_FILE")"
@@ -608,7 +644,8 @@ publish_detach_owner() {
     return 1
   fi
 
-  rm -f "$pid_backup" "$REPORT_FILE" "$HEARTBEAT_FILE"
+  rm -f "$pid_backup" "$REPORT_FILE" "$HEARTBEAT_FILE" "$LAST_MSG_FILE" "$STDOUT_FILE"
+  remove_run_artifacts "$old_run_id"
   release_owner_lock
   if [ "$FORCE" -eq 1 ]; then
     terminate_confirmed_old_process "$old_worker_pid" worker
@@ -619,7 +656,7 @@ publish_detach_owner() {
 
 publish_sync_owner() {
   local started_at="$1" runner_pid="${BASHPID:-$$}"
-  local old_runner_pid="" old_monitor_pid="" old_worker_pid=""
+  local old_run_id="" old_runner_pid="" old_monitor_pid="" old_worker_pid=""
   jq -n \
     --arg run_id "$RUN_ID" --argjson runner_pid "$runner_pid" --arg started_at "$started_at" \
     '{run_id:$run_id,run_kind:"sync",runner_pid:$runner_pid,
@@ -630,12 +667,18 @@ publish_sync_owner() {
   acquire_owner_lock || { rm -f "$OWNER_TMP"; return 1; }
   if { [ -e "$OWNER_FILE" ] || [ -e "$PID_FILE" ] || [ -e "$REPORT_FILE" ]; } &&
      [ "$FORCE" -ne 1 ] && [ -z "$RESUME" ]; then
+    if owner_is_valid "$OWNER_FILE" && jq -e '.run_kind=="sync"' "$OWNER_FILE" >/dev/null 2>&1 &&
+       [ "$(process_probe "$(jq -r '.runner_pid' "$OWNER_FILE")")" != absent ]; then
+      err "a live sync run for label '$LABEL' already owns the output paths"
+    else
+      err "a run for label '$LABEL' is already active (use --force to override)"
+    fi
     release_owner_lock
     rm -f "$OWNER_TMP"
-    err "a run for label '$LABEL' is already active (use --force to override)"
     return 1
   fi
   if owner_is_valid "$OWNER_FILE"; then
+    old_run_id="$(jq -r '.run_id' "$OWNER_FILE")"
     old_runner_pid="$(jq -r '.runner_pid // empty' "$OWNER_FILE")"
     old_monitor_pid="$(jq -r '.monitor_pid // empty' "$OWNER_FILE")"
     old_worker_pid="$(jq -r '.worker_pid // empty' "$OWNER_FILE")"
@@ -648,7 +691,8 @@ publish_sync_owner() {
     rm -f "$OWNER_TMP"
     return 1
   fi
-  rm -f "$PID_FILE" "$REPORT_FILE" "$HEARTBEAT_FILE"
+  rm -f "$PID_FILE" "$REPORT_FILE" "$HEARTBEAT_FILE" "$LAST_MSG_FILE" "$STDOUT_FILE"
+  remove_run_artifacts "$old_run_id"
   release_owner_lock
   if [ "$FORCE" -eq 1 ]; then
     terminate_confirmed_old_process "$old_worker_pid" worker
@@ -677,6 +721,16 @@ classify_handoff_metadata() {
   if [ -n "$expected_dev" ]; then [ "$dev" = "$expected_dev" ] || return 1; fi
   if [ -n "$expected_ino" ]; then [ "$ino" = "$expected_ino" ] || return 1; fi
   [ -n "$path" ]
+}
+
+handoff_path_name_is_safe() {
+  local path="$1" root="$2" launcher_pid="$3" base embedded_pid
+  [ -n "$path" ] && [ "${path#/}" != "$path" ] || return 1
+  [ "$(dirname "$path")" = "$root" ] || return 1
+  base="$(basename "$path")"
+  [[ "$base" =~ ^agent-delegate-handoff\.([0-9]+)\.[A-Za-z0-9_-]+$ ]] || return 1
+  embedded_pid="${BASH_REMATCH[1]}"
+  [ "$embedded_pid" = "$launcher_pid" ]
 }
 
 production_handoff_path_is_safe() {
@@ -708,28 +762,52 @@ production_handoff_path_is_safe() {
 }
 
 stale_reap_previous_run() {
-  local handoff run_id launcher_pid monitor_pid lease_at lease_epoch now pid_run pid_monitor
-  local initial_dev initial_ino sentinel child base remaining
+  local handoff run_id run_kind runner_pid launcher_pid monitor_pid lease_at lease_epoch now
+  local pid_run="" pid_monitor="" pid_present=0 initial_dev initial_ino sentinel child base remaining
   acquire_owner_lock || return 1
-  if ! owner_is_valid "$OWNER_FILE" || ! jq -e '.run_kind=="detach"' "$OWNER_FILE" >/dev/null 2>&1; then
+  if ! owner_is_valid "$OWNER_FILE"; then
     release_owner_lock
     return 0
   fi
-  handoff="$(jq -r '.handoff_dir // empty' "$OWNER_FILE")"
   run_id="$(jq -r '.run_id' "$OWNER_FILE")"
+  run_kind="$(jq -r '.run_kind' "$OWNER_FILE")"
+  runner_pid="$(jq -r '.runner_pid' "$OWNER_FILE")"
+  lease_at="$(jq -r '.lease_at' "$OWNER_FILE")"
+  lease_epoch="$(rfc3339_epoch "$lease_at" || true)"; now="$(date -u +%s)"
+
+  if [ "$run_kind" = sync ]; then
+    if ! jq -e '.monitor_pid==null and .handoff_dir==null and
+        .runner_pid==.launcher_pid and .runner_pid==.worker_pid' "$OWNER_FILE" >/dev/null 2>&1; then
+      err "stale-reaper retained invalid sync owner for run $run_id"
+      release_owner_lock
+      return 0
+    fi
+    if [ -e "$PID_FILE" ] || [ -L "$PID_FILE" ] || [ "$(process_probe "$runner_pid")" != absent ] ||
+       [ -z "$lease_epoch" ] || [ $((now - lease_epoch)) -le "$HEARTBEAT_FRESHNESS" ]; then
+      release_owner_lock
+      return 0
+    fi
+    if owner_matches_run "$run_id" && [ ! -e "$PID_FILE" ] && [ ! -L "$PID_FILE" ]; then
+      rm -f "$OWNER_FILE"
+    fi
+    release_owner_lock
+    return 0
+  fi
+
+  handoff="$(jq -r '.handoff_dir // empty' "$OWNER_FILE")"
   launcher_pid="$(jq -r '.launcher_pid' "$OWNER_FILE")"
   monitor_pid="$(jq -r '.monitor_pid // empty' "$OWNER_FILE")"
-  lease_at="$(jq -r '.lease_at' "$OWNER_FILE")"
-  if [ -z "$handoff" ] || ! production_handoff_path_is_safe "$handoff" "$HANDOFF_ROOT" "$launcher_pid"; then
-    err "stale-reaper retained unsafe handoff path for run $run_id"
+  if [ -z "$monitor_pid" ] || ! jq -e '.runner_pid==.monitor_pid' "$OWNER_FILE" >/dev/null 2>&1; then
+    err "stale-reaper retained run $run_id because detach owner is inconsistent"
     release_owner_lock
     return 0
   fi
-  initial_dev="$(stat_dev "$handoff")"; initial_ino="$(stat_ino "$handoff")"
-  pid_run="$(awk -F': ' '$1=="run_id"{print $2; exit}' "$PID_FILE" 2>/dev/null || true)"
-  pid_monitor="$(awk -F': ' '$1=="pid"{print $2; exit}' "$PID_FILE" 2>/dev/null || true)"
-  if [ "$pid_run" != "$run_id" ] || [ "$pid_monitor" != "$monitor_pid" ] ||
-     ! jq -e --argjson monitor "$monitor_pid" '.runner_pid==$monitor and .monitor_pid==$monitor' "$OWNER_FILE" >/dev/null 2>&1; then
+  if [ -e "$PID_FILE" ] || [ -L "$PID_FILE" ]; then
+    pid_present=1
+    pid_run="$(awk -F': ' '$1=="run_id"{print $2; exit}' "$PID_FILE" 2>/dev/null || true)"
+    pid_monitor="$(awk -F': ' '$1=="pid"{print $2; exit}' "$PID_FILE" 2>/dev/null || true)"
+  fi
+  if [ "$pid_present" -eq 1 ] && { [ "$pid_run" != "$run_id" ] || [ "$pid_monitor" != "$monitor_pid" ]; }; then
     err "stale-reaper retained run $run_id because owner and pid do not agree"
     release_owner_lock
     return 0
@@ -738,11 +816,31 @@ stale_reap_previous_run() {
     release_owner_lock
     return 0
   fi
-  lease_epoch="$(rfc3339_epoch "$lease_at" || true)"; now="$(date -u +%s)"
   if [ -z "$lease_epoch" ] || [ $((now - lease_epoch)) -le "$HEARTBEAT_FRESHNESS" ]; then
     release_owner_lock
     return 0
   fi
+
+  if [ ! -e "$handoff" ] && [ ! -L "$handoff" ]; then
+    if ! handoff_path_name_is_safe "$handoff" "$HANDOFF_ROOT" "$launcher_pid"; then
+      err "stale-reaper retained unsafe missing handoff path for run $run_id"
+      release_owner_lock
+      return 0
+    fi
+    if owner_matches_run "$run_id" && [ ! -e "$handoff" ] && [ ! -L "$handoff" ]; then
+      [ "$pid_present" -eq 0 ] || rm -f "$PID_FILE"
+      rm -f "$OWNER_FILE"
+    fi
+    release_owner_lock
+    return 0
+  fi
+
+  if [ "$pid_present" -ne 1 ] || ! production_handoff_path_is_safe "$handoff" "$HANDOFF_ROOT" "$launcher_pid"; then
+    err "stale-reaper retained unsafe handoff path for run $run_id"
+    release_owner_lock
+    return 0
+  fi
+  initial_dev="$(stat_dev "$handoff")"; initial_ino="$(stat_ino "$handoff")"
 
   sentinel="$handoff/handoff-sentinel.json"
   if [ -e "$sentinel" ]; then
@@ -763,6 +861,7 @@ stale_reap_previous_run() {
       esac
       child="$handoff/$base"
       production_handoff_path_is_safe "$handoff" "$HANDOFF_ROOT" "$launcher_pid" "$initial_dev" "$initial_ino" || { release_owner_lock; return 0; }
+      if [ ! -e "$child" ] && [ ! -L "$child" ]; then continue; fi
       [ ! -L "$child" ] && [ -p "$child" ] || { err "stale-reaper retained invalid_sentinel FIFO type for run $run_id"; release_owner_lock; return 0; }
       rm -f "$child"
     done < <(jq -r '.created_fifos[]' "$sentinel")
@@ -870,6 +969,41 @@ close_monitor_control_fds() {
 close_launcher_handoff_fds() {
   { exec 8<&-; } 2>/dev/null || true
   { exec 7>&-; } 2>/dev/null || true
+}
+
+monitor_setup_created_fifos() {
+  local base created="" names=(launcher-to-monitor.fifo monitor-to-launcher.fifo)
+  if heartbeat_test_mode; then names+=(harness-to-monitor.fifo monitor-to-harness.fifo); fi
+  for base in "${names[@]}"; do
+    if [ ! -L "$HANDOFF_DIR/$base" ] && [ -p "$HANDOFF_DIR/$base" ]; then
+      if [ -z "$created" ]; then created="$base"; else created="$created,$base"; fi
+    fi
+  done
+  printf '%s' "$created"
+}
+
+monitor_setup_signal_guard() {
+  local signal="$1" created
+  [ "$MONITOR_SETUP_GUARD_ARMED" -eq 1 ] || exit 2
+  MONITOR_SETUP_GUARD_ARMED=0
+  trap '' TERM INT HUP
+  created="$(monitor_setup_created_fifos)"
+  close_monitor_handoff_fds
+  write_handoff_sentinel setup_failed not_started readiness_timeout "$created" || true
+  err "detach monitor received $signal during readiness setup"
+  exit 2
+}
+
+arm_monitor_setup_guard() {
+  MONITOR_SETUP_GUARD_ARMED=1
+  trap 'monitor_setup_signal_guard TERM' TERM
+  trap 'monitor_setup_signal_guard INT' INT
+  trap 'monitor_setup_signal_guard HUP' HUP
+}
+
+disarm_monitor_setup_guard() {
+  MONITOR_SETUP_GUARD_ARMED=0
+  trap - TERM INT HUP
 }
 
 setup_monitor_handoff() {
@@ -1072,12 +1206,12 @@ build_cli_command() {
       # override is unverified there, so drop effort on resume rather than risk
       # an "unexpected argument" failure. Sandbox/model are already fixed at
       # session creation and cannot change on resume anyway.
-      CLI_CMD=( codex exec resume "$RESUME" --json --output-last-message "$LAST_MSG_FILE" )
+      CLI_CMD=( codex exec resume "$RESUME" --json --output-last-message "$RUN_LAST_MSG_FILE" )
       if [ -n "$EFFORT" ]; then err "warning: --effort is ignored on codex resume (session settings are fixed at creation)"; fi
     else
       CLI_CMD=( codex exec --sandbox "$CODEX_SANDBOX_VALUE" )
       if [ -n "$MODEL" ]; then CLI_CMD+=( --model "$MODEL" ); fi
-      CLI_CMD+=( --skip-git-repo-check --json --output-last-message "$LAST_MSG_FILE" )
+      CLI_CMD+=( --skip-git-repo-check --json --output-last-message "$RUN_LAST_MSG_FILE" )
       if [ -n "$EFFORT" ]; then CLI_CMD+=( -c "model_reasoning_effort=\"$EFFORT\"" ); fi
     fi
   else
@@ -1100,9 +1234,9 @@ build_cli_command() {
 extract_thread_id() {
   local id=""
   if [ "$TARGET" = "codex" ]; then
-    id="$(jq -rc 'select(.type == "thread.started") | .thread_id' "$STDOUT_FILE" 2>/dev/null | awk 'NF {print; exit}')" || true
+    id="$(jq -rc 'select(.type == "thread.started") | .thread_id' "$RUN_STDOUT_FILE" 2>/dev/null | awk 'NF {print; exit}')" || true
   else
-    id="$(jq -r '.session_id // empty' "$STDOUT_FILE" 2>/dev/null | awk 'NF {print; exit}')" || true
+    id="$(jq -r '.session_id // empty' "$RUN_STDOUT_FILE" 2>/dev/null | awk 'NF {print; exit}')" || true
   fi
   if [ -z "$id" ]; then
     # Continuing a session keeps its id even if the resume output omits it.
@@ -1139,6 +1273,9 @@ classify_blocker() {
 # BLOCKER_CATEGORY, THREAD_ID, TOUCHED_LIST_FILE, plus meta/artifact paths.
 write_report() {
   local blocker_json="null" cat_json="null"
+  if [ "$REPORT_IS_CANDIDATE" -eq 0 ]; then
+    publish_run_artifacts || return $?
+  fi
   if [ -n "${BLOCKER:-}" ]; then blocker_json="$(printf '%s' "$BLOCKER" | jq -R -s '.')"; fi
   if [ -n "${BLOCKER_CATEGORY:-}" ]; then cat_json="$(printf '%s' "$BLOCKER_CATEGORY" | jq -R '.')"; fi
 
@@ -1225,7 +1362,7 @@ compute_touched() {
 
 # --- core run: drive the peer CLI once -------------------------------------
 #
-# Sets: RUN_RC, and writes STDOUT_FILE/STDERR_FILE/LAST_MSG_FILE. Also produces
+# Sets: RUN_RC, and writes RUN_STDOUT_FILE/STDERR_FILE/RUN_LAST_MSG_FILE. Also produces
 # TOUCHED_LIST_FILE (filtered) and THREAD_ID. $1 = prompt file to feed on stdin.
 RUN_RC=0
 run_cli() {
@@ -1242,18 +1379,18 @@ run_cli() {
 
   RUN_RC=0
   if [ "$RUN_CLI_APPEND_STDERR" -eq 1 ]; then
-    "${CLI_CMD[@]}" < "$prompt_used" > "$STDOUT_FILE" 2>> "$STDERR_FILE" || RUN_RC=$?
+    "${CLI_CMD[@]}" < "$prompt_used" > "$RUN_STDOUT_FILE" 2>> "$STDERR_FILE" || RUN_RC=$?
   else
-    "${CLI_CMD[@]}" < "$prompt_used" > "$STDOUT_FILE" 2> "$STDERR_FILE" || RUN_RC=$?
+    "${CLI_CMD[@]}" < "$prompt_used" > "$RUN_STDOUT_FILE" 2> "$STDERR_FILE" || RUN_RC=$?
   fi
 
   snapshot_changed_files > "$post"
   compute_touched "$pre" "$post" > "$TOUCHED_LIST_FILE"
 
   # For claude, the final message lives in the result JSON; materialize it into
-  # LAST_MSG_FILE so artifacts.last_message is consistent across directions.
+  # RUN_LAST_MSG_FILE so artifacts.last_message is consistent across directions.
   if [ "$TARGET" = "claude" ]; then
-    jq -r '.result // .text // empty' "$STDOUT_FILE" 2>/dev/null > "$LAST_MSG_FILE" || true
+    jq -r '.result // .text // empty' "$RUN_STDOUT_FILE" 2>/dev/null > "$RUN_LAST_MSG_FILE" || true
   fi
 
   THREAD_ID="$(extract_thread_id)"
@@ -1263,7 +1400,7 @@ run_cli() {
 run_delegate() {
   run_cli "$PROMPT_FILE"
 
-  SUMMARY="$(summarize_last_message "$LAST_MSG_FILE")"
+  SUMMARY="$(summarize_last_message "$RUN_LAST_MSG_FILE")"
   BLOCKER=""; BLOCKER_CATEGORY=""
   if [ "$RUN_RC" -ne 0 ]; then
     REPORT_STATUS="blocked"
@@ -1306,7 +1443,7 @@ run_review() {
   rm -f "$combined"
 
   BLOCKER=""; BLOCKER_CATEGORY=""
-  SUMMARY="$(summarize_last_message "$LAST_MSG_FILE")"
+  SUMMARY="$(summarize_last_message "$RUN_LAST_MSG_FILE")"
 
   if [ "$RUN_RC" -ne 0 ]; then
     REPORT_STATUS="blocked"
@@ -1318,14 +1455,14 @@ run_review() {
 
   # Machine-verify the 4 contract points on the final message.
   local missing=()
-  grep -q '^type: review'                         "$LAST_MSG_FILE" || missing+=("type: review")
-  grep -q '^## Meta'                              "$LAST_MSG_FILE" || missing+=("## Meta")
-  grep -q '^## Findings'                          "$LAST_MSG_FILE" || missing+=("## Findings")
-  grep -q '^### Critical'                         "$LAST_MSG_FILE" || missing+=("### Critical")
-  grep -q '^### Improvement'                      "$LAST_MSG_FILE" || missing+=("### Improvement")
-  grep -q '^### Minor'                            "$LAST_MSG_FILE" || missing+=("### Minor")
-  grep -q '^## Summary'                           "$LAST_MSG_FILE" || missing+=("## Summary")
-  grep -qE 'Gate:[[:space:]]*(PASS|FAIL)'         "$LAST_MSG_FILE" || missing+=("Gate: PASS|FAIL")
+  grep -q '^type: review'                         "$RUN_LAST_MSG_FILE" || missing+=("type: review")
+  grep -q '^## Meta'                              "$RUN_LAST_MSG_FILE" || missing+=("## Meta")
+  grep -q '^## Findings'                          "$RUN_LAST_MSG_FILE" || missing+=("## Findings")
+  grep -q '^### Critical'                         "$RUN_LAST_MSG_FILE" || missing+=("### Critical")
+  grep -q '^### Improvement'                      "$RUN_LAST_MSG_FILE" || missing+=("### Improvement")
+  grep -q '^### Minor'                            "$RUN_LAST_MSG_FILE" || missing+=("### Minor")
+  grep -q '^## Summary'                           "$RUN_LAST_MSG_FILE" || missing+=("## Summary")
+  grep -qE 'Gate:[[:space:]]*(PASS|FAIL)'         "$RUN_LAST_MSG_FILE" || missing+=("Gate: PASS|FAIL")
 
   if [ "${#missing[@]}" -gt 0 ]; then
     # Join with ", " manually: parameter expansion with IFS uses only the first
@@ -1344,7 +1481,7 @@ run_review() {
 
   # Well-formed: persist the review file from the final message.
   mkdir -p "$(dirname "$REVIEW_FILE")"
-  cp "$LAST_MSG_FILE" "$REVIEW_FILE"
+  cp "$RUN_LAST_MSG_FILE" "$REVIEW_FILE"
 
   # read-only must not have modified the workspace (excluding our own artifacts).
   if [ -s "$TOUCHED_LIST_FILE" ]; then
@@ -1495,6 +1632,7 @@ publish_worker_candidate() {
   fi
   report_is_terminal_for_run "$CANDIDATE_FILE" "$RUN_ID" || return 1
   status="$(jq -r '.status' "$CANDIDATE_FILE")"
+  publish_run_artifacts || return $?
   owner_publish_path "$RUN_ID" "$CANDIDATE_FILE" "$REPORT_FILE" 1 "$MONITOR_PID" || return $?
   printf '%s' "$status"
 }
@@ -1779,12 +1917,15 @@ run_monitor() {
   compute_paths
   local started_at monitor_pid worker_pid worker_rc=0 heartbeat_pid terminal_status phase
   started_at="$(utc_now)"; monitor_pid="${BASHPID:-$$}"; MONITOR_PID="$monitor_pid"
+  arm_monitor_setup_guard
   if ! publish_detach_owner "$monitor_pid" "$started_at"; then
+    disarm_monitor_setup_guard
     err "failed to publish detach owner and pid"
     return 2
   fi
   : > "$STDERR_FILE"
   if ! setup_monitor_handoff; then
+    disarm_monitor_setup_guard
     phase="setup_failed"
     if [ "$(process_probe "$LAUNCHER_PID")" = absent ]; then
       publish_handoff_failure_once "$phase" "$monitor_pid" || err "failed to publish setup failure report"
@@ -1793,6 +1934,7 @@ run_monitor() {
     fi
     return 2
   fi
+  disarm_monitor_setup_guard
   if ! monitor_handoff; then
     printf 'handoff-failed %s protocol\n' "$RUN_ID" >&10 2>/dev/null || true
     close_monitor_handoff_fds
@@ -2014,12 +2156,20 @@ compute_paths
 
 # A prior launcher may have died after its parent returned. Reap only a stale,
 # fully validated run; ambiguous or live state remains a collision.
-stale_reap_previous_run
+if ! stale_reap_previous_run; then
+  err "stale-reaper could not acquire the owner lock; refusing to start"
+  exit 2
+fi
 
 # Collision guard: a live pid file, or a prior report we are not resuming, is a
 # refuse-by-default (override with --force).
 if { [ -f "$PID_FILE" ] || [ -f "$OWNER_FILE" ]; } && [ "$FORCE" -ne 1 ]; then
-  err "a run for label '$LABEL' is already tracked at $PID_FILE (use --force to override)"
+  if owner_is_valid "$OWNER_FILE" && jq -e '.run_kind=="sync"' "$OWNER_FILE" >/dev/null 2>&1 &&
+     [ "$(process_probe "$(jq -r '.runner_pid' "$OWNER_FILE")")" != absent ]; then
+    err "a live sync run for label '$LABEL' already owns the output paths"
+  else
+    err "a run for label '$LABEL' is already tracked at $PID_FILE (use --force to override)"
+  fi
   exit 2
 fi
 if [ -f "$REPORT_FILE" ] && [ -z "$RESUME" ] && [ "$FORCE" -ne 1 ]; then

--- a/skills/agent-delegate/references/scripts/agent-delegate.sh
+++ b/skills/agent-delegate/references/scripts/agent-delegate.sh
@@ -860,6 +860,7 @@ stale_reap_previous_run() {
       return 0
     fi
     if owner_matches_run "$run_id" && [ ! -e "$handoff" ] && [ ! -L "$handoff" ]; then
+      if [ "$FORCE" -eq 1 ]; then terminate_confirmed_old_monitor_group "$monitor_pid"; fi
       [ "$pid_present" -eq 0 ] || rm -f "$PID_FILE"
       rm -f "$OWNER_FILE"
     fi
@@ -926,6 +927,7 @@ stale_reap_previous_run() {
   production_handoff_path_is_safe "$handoff" "$HANDOFF_ROOT" "$launcher_pid" "$initial_dev" "$initial_ino" || { release_owner_lock; return 0; }
   rmdir "$handoff" || { release_owner_lock; return 0; }
   if owner_matches_run "$run_id" && pid_matches_run "$run_id" "$monitor_pid"; then
+    if [ "$FORCE" -eq 1 ]; then terminate_confirmed_old_monitor_group "$monitor_pid"; fi
     rm -f "$PID_FILE" "$OWNER_FILE"
   fi
   release_owner_lock

--- a/skills/agent-delegate/references/scripts/tests/fixtures/abnormal-cleanup-cases.tsv
+++ b/skills/agent-delegate/references/scripts/tests/fixtures/abnormal-cleanup-cases.tsv
@@ -1,0 +1,7 @@
+case_id	expected_behavior
+stale-detach-and-sync-owner	stale owners are reclaimed only when owner run path and type relations are valid
+live-sync-collision	live owner and shared outputs remain unchanged and the colliding run exits 2
+stale-reaper-lock-timeout	lock timeout exits 2 without publishing shared runtime artifacts
+force-orphan-peer-isolation	force stops the stale monitor process group before the new run publishes artifacts
+setup-term-readiness-sentinel	TERM before FIFO readiness records failure_stage readiness_timeout
+partial-handoff-safe-cleanup	missing listed FIFOs are tolerated while unsafe paths symlinks and unknown entries are retained

--- a/skills/agent-delegate/references/scripts/tests/fixtures/case-manifest.tsv
+++ b/skills/agent-delegate/references/scripts/tests/fixtures/case-manifest.tsv
@@ -24,3 +24,4 @@ T-A22	all-repeat-3	meta	repeat-suite	case-manifest.tsv	repeat-manifests
 T-A23	caller-initial-heartbeat-death	suite	state-and-runtime	caller-initial-heartbeat.tsv	initial-window-state-and-runtime-evidence
 T-A24	caller-state-priority	suite	state-fixture	caller-priority.tsv	priority-state-decisions
 T-A25	caller-wait-upper-bound	suite	wait-bound-fixture	caller-wait-bounds.tsv	reevaluation-stop-and-escalation-decisions
+T-A26	abnormal-cleanup-real-filesystem	suite	abnormal-cleanup	abnormal-cleanup-cases.tsv	six-abnormal-cleanup-paths

--- a/skills/agent-delegate/references/scripts/tests/run_tests.sh
+++ b/skills/agent-delegate/references/scripts/tests/run_tests.sh
@@ -428,6 +428,331 @@ run_sync() {
   ' "$report" >/dev/null
 }
 
+pid_is_running() {
+  local state
+  state="$(ps -o stat= -p "$1" 2>/dev/null | tr -d '[:space:]')"
+  [ -n "$state" ] && [[ "$state" != Z* ]]
+}
+
+wait_for_pid_stop() {
+  local pid="$1" deadline=$(( $(date -u +%s) + 10 ))
+  while [ "$(date -u +%s)" -lt "$deadline" ]; do
+    pid_is_running "$pid" || return 0
+  done
+  return 1
+}
+
+run_stale_detach_and_sync_owner() (
+  local root dir label handoff probe_handoff monitor rc owner_hash pid_hash barrier sync_pid peer old_run new_run deadline
+  root="$(cd "${TMPDIR:-/tmp}" && pwd)"
+  dir="$(new_work_dir)"
+  trap '[ -z "${sync_pid:-}" ] || kill -TERM "$sync_pid" 2>/dev/null || true
+    [ -z "${peer:-}" ] || kill -TERM "$peer" 2>/dev/null || true
+    rm -rf "$dir" "${handoff:-}" "${probe_handoff:-}"' EXIT TERM INT HUP
+  printf 'prompt\n' > "$dir/prompt.md"
+
+  label=stale-detach
+  monitor="$(absent_test_pid)"
+  handoff="$root/agent-delegate-handoff.101.missing"
+  rm -rf "$handoff"
+  jq -n --arg handoff "$handoff" --argjson monitor "$monitor" '
+    {run_id:"stale-detach-run",run_kind:"detach",runner_pid:$monitor,launcher_pid:101,
+     monitor_pid:$monitor,worker_pid:null,started_at:"2000-01-01T00:00:00Z",
+     lease_at:"2000-01-01T00:00:00Z",handoff_dir:$handoff,handoff_phase:"not_started"}
+  ' > "$dir/$label-owner.json"
+  printf 'pid: %s\nrun_id: stale-detach-run\n' "$monitor" > "$dir/$label.pid"
+  probe_handoff="$(mktemp -d "$root/agent-delegate-heartbeat-handoff.XXXXXX")"; chmod 700 "$probe_handoff"
+  set +e
+  AGENT_DELEGATE_TEST_MODE=heartbeat AGENT_DELEGATE_TEST_HANDOFF_DIR="$probe_handoff" \
+    AGENT_DELEGATE_TEST_FAIL_STAGE=new_pid bash "$SCRIPT" --mode delegate --prompt-file "$dir/prompt.md" \
+      --out-dir "$dir" --label "$label" --target claude --detach > "$dir/$label.out" 2> "$dir/$label.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] && [ ! -e "$dir/$label-owner.json" ] && [ ! -e "$dir/$label.pid" ] || return 1
+  rm -rf "$probe_handoff"; probe_handoff=""
+
+  label=stale-detach-negative
+  handoff="$root/agent-delegate-handoff.101.owner-mismatch"
+  rm -rf "$handoff"
+  jq -n --arg handoff "$handoff" --argjson monitor "$monitor" '
+    {run_id:"negative-detach-run",run_kind:"detach",runner_pid:$monitor,launcher_pid:102,
+     monitor_pid:$monitor,worker_pid:null,started_at:"2000-01-01T00:00:00Z",
+     lease_at:"2000-01-01T00:00:00Z",handoff_dir:$handoff,handoff_phase:"not_started"}
+  ' > "$dir/$label-owner.json"
+  printf 'pid: %s\nrun_id: negative-detach-run\n' "$monitor" > "$dir/$label.pid"
+  owner_hash="$(sha256_file "$dir/$label-owner.json")"; pid_hash="$(sha256_file "$dir/$label.pid")"
+  probe_handoff="$(mktemp -d "$root/agent-delegate-heartbeat-handoff.XXXXXX")"; chmod 700 "$probe_handoff"
+  set +e
+  AGENT_DELEGATE_TEST_MODE=heartbeat AGENT_DELEGATE_TEST_HANDOFF_DIR="$probe_handoff" \
+    AGENT_DELEGATE_TEST_FAIL_STAGE=new_pid bash "$SCRIPT" --mode delegate --prompt-file "$dir/prompt.md" \
+      --out-dir "$dir" --label "$label" --target claude --detach > "$dir/$label.out" 2> "$dir/$label.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] && [ "$(sha256_file "$dir/$label-owner.json")" = "$owner_hash" ] &&
+    [ "$(sha256_file "$dir/$label.pid")" = "$pid_hash" ] || return 1
+  rm -rf "$probe_handoff"; probe_handoff=""
+
+  label=stale-sync; barrier="$dir/sync-barrier"; mkdir "$barrier"; mkfifo "$barrier/release.fifo"
+  PATH="$STUB_DIR:$PATH" AGENT_DELEGATE_STUB_BARRIER_DIR="$barrier" bash "$SCRIPT" --mode delegate \
+    --prompt-file "$dir/prompt.md" --out-dir "$dir" --label "$label" --target claude --sandbox workspace-write \
+    > "$dir/$label-old.out" 2> "$dir/$label-old.err" &
+  sync_pid=$!; deadline=$(( $(date -u +%s) + 10 ))
+  while [ "$(date -u +%s)" -lt "$deadline" ]; do
+    [ -f "$barrier/claude.ready" ] && [ -f "$dir/$label-owner.json" ] && break
+    pid_is_running "$sync_pid" || break
+  done
+  [ -f "$dir/$label-owner.json" ] && [ -f "$barrier/claude.pid" ] || return 1
+  peer="$(cat "$barrier/claude.pid")"; old_run="$(jq -r '.run_id' "$dir/$label-owner.json")"
+  kill -KILL "$sync_pid"; wait "$sync_pid" 2>/dev/null || true
+  jq '.lease_at="2000-01-01T00:00:00Z"' "$dir/$label-owner.json" > "$dir/$label-owner.tmp"
+  mv "$dir/$label-owner.tmp" "$dir/$label-owner.json"
+  run_sync "$dir" "$label" claude delegate done
+  new_run="$(jq -r '.meta.run_id' "$dir/$label-report.json")"
+  [ "$new_run" != "$old_run" ] && [ ! -e "$dir/$label-owner.json" ] || return 1
+  if pid_is_running "$peer"; then printf 'release\n' > "$barrier/release.fifo"; fi
+  wait_for_pid_stop "$peer" || kill -KILL "$peer" 2>/dev/null || true
+)
+
+run_live_sync_collision() (
+  local dir label=live-sync barrier owner run pid peer deadline rc owner_hash report_hash stdout_hash last_hash
+  dir="$(new_work_dir)"
+  trap '[ -z "${pid:-}" ] || kill -TERM "$pid" 2>/dev/null || true
+    [ -z "${peer:-}" ] || kill -TERM "$peer" 2>/dev/null || true
+    rm -rf "$dir"' EXIT TERM INT HUP
+  barrier="$dir/barrier"; mkdir "$barrier"; mkfifo "$barrier/release.fifo"; printf 'prompt\n' > "$dir/prompt.md"
+  PATH="$STUB_DIR:$PATH" AGENT_DELEGATE_STUB_BARRIER_DIR="$barrier" bash "$SCRIPT" --mode delegate \
+    --prompt-file "$dir/prompt.md" --out-dir "$dir" --label "$label" --target claude --sandbox workspace-write \
+    > "$dir/first.out" 2> "$dir/first.err" &
+  pid=$!; deadline=$(( $(date -u +%s) + 10 )); owner="$dir/$label-owner.json"
+  while [ "$(date -u +%s)" -lt "$deadline" ]; do
+    [ -f "$barrier/claude.ready" ] && [ -f "$owner" ] && break
+    pid_is_running "$pid" || break
+  done
+  [ -f "$owner" ] || return 1
+  run="$(jq -r '.run_id' "$owner")"; peer="$(cat "$barrier/claude.pid")"
+  printf '{"protected":"report"}\n' > "$dir/$label-report.json"
+  printf '{"protected":"stdout"}\n' > "$dir/$label-stdout.json"
+  printf 'protected last\n' > "$dir/$label-last.txt"
+  owner_hash="$(sha256_file "$owner")"; report_hash="$(sha256_file "$dir/$label-report.json")"
+  stdout_hash="$(sha256_file "$dir/$label-stdout.json")"; last_hash="$(sha256_file "$dir/$label-last.txt")"
+  set +e
+  PATH="$STUB_DIR:$PATH" bash "$SCRIPT" --mode delegate --prompt-file "$dir/prompt.md" --out-dir "$dir" \
+    --label "$label" --target claude > "$dir/collision.out" 2> "$dir/collision.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] && grep -q "live sync run for label '$label'" "$dir/collision.err" || return 1
+  [ "$(sha256_file "$owner")" = "$owner_hash" ] && [ "$(sha256_file "$dir/$label-report.json")" = "$report_hash" ] &&
+    [ "$(sha256_file "$dir/$label-stdout.json")" = "$stdout_hash" ] && [ "$(sha256_file "$dir/$label-last.txt")" = "$last_hash" ] || return 1
+  jq -e --arg run "$run" '.run_id==$run and .run_kind=="sync"' "$owner" >/dev/null || return 1
+  [ ! -e "$dir/$label.pid" ] && [ ! -e "$dir/$label-heartbeat.json" ] || return 1
+  printf 'release\n' > "$barrier/release.fifo"; wait "$pid"
+  jq -e --arg run "$run" '.meta.run_id==$run and .status=="done"' "$dir/$label-report.json" >/dev/null
+)
+
+run_stale_reaper_lock_timeout() (
+  local dir label=lock-timeout rc
+  dir="$(new_work_dir)"; trap 'rm -rf "$dir"' EXIT TERM INT HUP
+  printf 'prompt\n' > "$dir/prompt.md"; mkdir "$dir/$label-owner.lock"
+  printf 'pid: %s\nrun_id: live-lock-holder\n' "${BASHPID:-$$}" > "$dir/$label-owner.lock/holder"
+  set +e
+  PATH="$STUB_DIR:$PATH" bash "$SCRIPT" --mode delegate --prompt-file "$dir/prompt.md" --out-dir "$dir" \
+    --label "$label" --target claude > "$dir/launch.out" 2> "$dir/launch.err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] && grep -q 'stale-reaper could not acquire the owner lock' "$dir/launch.err" || return 1
+  [ -d "$dir/$label-owner.lock" ] && [ -f "$dir/$label-owner.lock/holder" ] || return 1
+  [ ! -e "$dir/$label-report.json" ] && [ ! -e "$dir/$label-owner.json" ] && [ ! -e "$dir/$label.pid" ] &&
+    [ ! -e "$dir/$label-heartbeat.json" ] && [ ! -e "$dir/$label-stdout.json" ] && [ ! -e "$dir/$label-last.txt" ]
+)
+
+run_force_orphan_peer_isolation() (
+  local dir label=force-orphan barrier owner monitor worker peer handoff old_run new_run before_stdout before_last
+  dir="$(new_work_dir)"; barrier="$dir/barrier"
+  trap 'cleanup_detach_stub_fixture "$dir" "$label"' EXIT TERM INT HUP
+  mkdir "$barrier"; mkfifo "$barrier/release.fifo"; printf 'prompt\n' > "$dir/prompt.md"
+  launch_detach_review_stub "$dir" "$label" "$barrier" || return 1
+  wait_for_detach_stub_runtime "$dir" "$label" "$barrier" || return 1
+  owner="$dir/$label-owner.json"; monitor="$(jq -r '.monitor_pid' "$owner")"; worker="$(jq -r '.worker_pid' "$owner")"
+  peer="$(cat "$barrier/claude.pid")"; handoff="$(jq -r '.handoff_dir' "$owner")"; old_run="$(jq -r '.run_id' "$owner")"
+  [ "$(process_group_of "$monitor")" = "$monitor" ] && pid_is_running "$peer" || return 1
+  kill -KILL "$worker" "$monitor" 2>/dev/null || return 1
+  wait_for_pid_stop "$worker" || return 1; wait_for_pid_stop "$monitor" || return 1
+  pid_is_running "$peer" || return 1
+  jq '.lease_at="2000-01-01T00:00:00Z"' "$owner" > "$owner.tmp"; mv "$owner.tmp" "$owner"
+  rm -rf "$handoff"
+  run_sync "$dir" "$label" claude delegate done --force
+  new_run="$(jq -r '.meta.run_id' "$dir/$label-report.json")"
+  [ "$new_run" != "$old_run" ] && wait_for_pid_stop "$peer" || return 1
+  jq -e --arg run "$new_run" '.meta.run_id==$run and .status=="done"' "$dir/$label-report.json" >/dev/null || return 1
+  jq -e '.session_id=="stub-claude-session" and .result=="stub claude completed"' "$dir/$label-stdout.json" >/dev/null || return 1
+  [ "$(cat "$dir/$label-last.txt")" = 'stub claude completed' ] || return 1
+  before_stdout="$(sha256_file "$dir/$label-stdout.json")"; before_last="$(sha256_file "$dir/$label-last.txt")"
+  [ "$(sha256_file "$dir/$label-stdout.json")" = "$before_stdout" ] &&
+    [ "$(sha256_file "$dir/$label-last.txt")" = "$before_last" ]
+)
+
+check_readiness_timeout_sentinel() {
+  local sentinel="$1" owner="$2"
+  jq -e --slurpfile owner "$owner" '
+    .state=="setup_failed" and .failure_stage=="readiness_timeout" and
+    .handoff_phase=="not_started" and .run_id==$owner[0].run_id and
+    .launcher_pid==$owner[0].launcher_pid and .monitor_pid==$owner[0].monitor_pid and
+    (.created_fifos|type)=="array"
+  ' "$sentinel" >/dev/null
+}
+
+run_setup_term_readiness_sentinel() (
+  local root dir label=setup-term handoff barrier bin real_mkfifo launcher monitor deadline rc sentinel owner bad
+  root="$(cd "${TMPDIR:-/tmp}" && pwd)"; dir="$(new_work_dir)"; barrier="$dir/barrier"; bin="$dir/bin"
+  handoff="$(mktemp -d "$root/agent-delegate-heartbeat-handoff.XXXXXX")"; chmod 700 "$handoff"
+  trap '[ -z "${monitor:-}" ] || kill -TERM "$monitor" 2>/dev/null || true
+    [ -z "${launcher:-}" ] || kill -TERM "$launcher" 2>/dev/null || true
+    rm -rf "$dir" "$handoff"' EXIT TERM INT HUP
+  mkdir "$barrier" "$bin"; mkfifo "$barrier/release.fifo"; printf 'prompt\n' > "$dir/prompt.md"
+  real_mkfifo="$(command -v mkfifo)"
+  cat > "$bin/mkfifo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+"$AGENT_DELEGATE_REAL_MKFIFO" "$@"
+if mkdir "$AGENT_DELEGATE_MKFIFO_ONCE" 2>/dev/null; then
+  printf 'ready\n' > "$AGENT_DELEGATE_MKFIFO_READY"
+  IFS= read -r _ < "$AGENT_DELEGATE_MKFIFO_RELEASE"
+fi
+EOF
+  chmod +x "$bin/mkfifo"
+  PATH="$bin:$STUB_DIR:$PATH" AGENT_DELEGATE_REAL_MKFIFO="$real_mkfifo" \
+    AGENT_DELEGATE_MKFIFO_ONCE="$barrier/once" AGENT_DELEGATE_MKFIFO_READY="$barrier/mkfifo.ready" \
+    AGENT_DELEGATE_MKFIFO_RELEASE="$barrier/release.fifo" AGENT_DELEGATE_TEST_MODE=heartbeat \
+    AGENT_DELEGATE_TEST_HANDOFF_DIR="$handoff" bash "$SCRIPT" --mode delegate --prompt-file "$dir/prompt.md" \
+      --out-dir "$dir" --label "$label" --target claude --detach > "$dir/launch.out" 2> "$dir/launch.err" &
+  launcher=$!; deadline=$(( $(date -u +%s) + 10 )); owner="$dir/$label-owner.json"
+  while [ "$(date -u +%s)" -lt "$deadline" ]; do
+    [ -f "$owner" ] && [ -f "$barrier/mkfifo.ready" ] && break
+    pid_is_running "$launcher" || break
+  done
+  [ -f "$owner" ] && [ -f "$barrier/mkfifo.ready" ] || return 1
+  monitor="$(jq -r '.monitor_pid' "$owner")"; kill -TERM "$monitor"
+  printf 'release\n' > "$barrier/release.fifo"
+  set +e; wait "$launcher"; rc=$?; set -e
+  [ "$rc" -eq 0 ] || return 1
+  sentinel="$dir/$label-handoff-sentinel-final.json"; owner="$dir/$label-owner-final.json"
+  check_readiness_timeout_sentinel "$sentinel" "$owner" || return 1
+  jq -e '.status=="blocked" and .blocker_category=="env_error"' "$dir/$label-report.json" >/dev/null || return 1
+  bad="$dir/$label-handoff-sentinel.negative.json"; jq '.run_id="corrupted-run"' "$sentinel" > "$bad"
+  if check_readiness_timeout_sentinel "$bad" "$owner"; then return 1; fi
+  [ ! -e "$dir/$label-owner.json" ] && [ ! -e "$dir/$label.pid" ] && [ ! -d "$handoff" ]
+)
+
+write_stale_detach_records() {
+  local dir="$1" label="$2" handoff="$3" run="$4" launcher="$5" monitor="$6"
+  jq -n --arg run "$run" --arg handoff "$handoff" --argjson launcher "$launcher" --argjson monitor "$monitor" '
+    {run_id:$run,run_kind:"detach",runner_pid:$monitor,launcher_pid:$launcher,monitor_pid:$monitor,
+     worker_pid:null,started_at:"2000-01-01T00:00:00Z",lease_at:"2000-01-01T00:00:00Z",
+     handoff_dir:$handoff,handoff_phase:"not_started"}
+  ' > "$dir/$label-owner.json"
+  printf 'pid: %s\nrun_id: %s\n' "$monitor" "$run" > "$dir/$label.pid"
+}
+
+write_stale_sentinel() {
+  local path="$1" run="$2" launcher="$3" monitor="$4" handoff="$5"
+  jq -n --arg run "$run" --arg handoff "$handoff" --argjson launcher "$launcher" --argjson monitor "$monitor" '
+    {run_id:$run,launcher_pid:$launcher,monitor_pid:$monitor,handoff_dir:$handoff,
+     created_fifos:["launcher-to-monitor.fifo","monitor-to-launcher.fifo"]}
+  ' > "$path"
+}
+
+run_partial_handoff_safe_cleanup() (
+  local root variant dir label handoff target probe monitor run rc expected owner_hash pid_hash
+  root="$(cd "${TMPDIR:-/tmp}" && pwd)"; monitor="$(absent_test_pid)"
+  trap 'rm -rf "${probe:-}" "${handoff:-}" "${target:-}" "${dir:-}"' EXIT TERM INT HUP
+  for variant in missing-listed-fifo outside-root symlink unknown-entry sentinel-run-mismatch fifo-type-mismatch; do
+    dir="$(new_work_dir)"; label="partial-$variant"; run="run-$variant"; printf 'prompt\n' > "$dir/prompt.md"
+    target=""; expected=retain
+    case "$variant" in
+      missing-listed-fifo)
+        handoff="$(mktemp -d "$root/agent-delegate-handoff.101.XXXXXX")"; chmod 700 "$handoff"
+        mkfifo "$handoff/launcher-to-monitor.fifo"; expected=remove ;;
+      outside-root)
+        handoff="$dir/agent-delegate-handoff.101.outside"; mkdir -m 700 "$handoff"
+        mkfifo "$handoff/launcher-to-monitor.fifo" ;;
+      symlink)
+        target="$dir/symlink-target"; mkdir -m 700 "$target"; mkfifo "$target/launcher-to-monitor.fifo"
+        handoff="$root/agent-delegate-handoff.101.symlink"; rm -f "$handoff"; ln -s "$target" "$handoff" ;;
+      unknown-entry)
+        handoff="$(mktemp -d "$root/agent-delegate-handoff.101.XXXXXX")"; chmod 700 "$handoff"
+        mkfifo "$handoff/launcher-to-monitor.fifo"; printf 'protected\n' > "$handoff/unknown-entry" ;;
+      sentinel-run-mismatch)
+        handoff="$(mktemp -d "$root/agent-delegate-handoff.101.XXXXXX")"; chmod 700 "$handoff"
+        mkfifo "$handoff/launcher-to-monitor.fifo" ;;
+      fifo-type-mismatch)
+        handoff="$(mktemp -d "$root/agent-delegate-handoff.101.XXXXXX")"; chmod 700 "$handoff"
+        printf 'not a fifo\n' > "$handoff/launcher-to-monitor.fifo" ;;
+    esac
+    write_stale_sentinel "$handoff/handoff-sentinel.json" "$run" 101 "$monitor" "$handoff"
+    if [ "$variant" = sentinel-run-mismatch ]; then
+      jq '.run_id="corrupted-run"' "$handoff/handoff-sentinel.json" > "$handoff/s.tmp"
+      mv "$handoff/s.tmp" "$handoff/handoff-sentinel.json"
+    fi
+    write_stale_detach_records "$dir" "$label" "$handoff" "$run" 101 "$monitor"
+    owner_hash="$(sha256_file "$dir/$label-owner.json")"; pid_hash="$(sha256_file "$dir/$label.pid")"
+    probe="$(mktemp -d "$root/agent-delegate-heartbeat-handoff.XXXXXX")"; chmod 700 "$probe"
+    set +e
+    AGENT_DELEGATE_TEST_MODE=heartbeat AGENT_DELEGATE_TEST_HANDOFF_DIR="$probe" AGENT_DELEGATE_TEST_FAIL_STAGE=new_pid \
+      bash "$SCRIPT" --mode delegate --prompt-file "$dir/prompt.md" --out-dir "$dir" --label "$label" \
+        --target claude --detach > "$dir/launch.out" 2> "$dir/launch.err"
+    rc=$?
+    set -e
+    [ "$rc" -eq 2 ] || return 1
+    if [ "$expected" = remove ]; then
+      [ ! -e "$handoff" ] && [ ! -L "$handoff" ] && [ ! -e "$dir/$label-owner.json" ] && [ ! -e "$dir/$label.pid" ] || return 1
+    else
+      { [ -d "$handoff" ] || [ -L "$handoff" ]; } && [ "$(sha256_file "$dir/$label-owner.json")" = "$owner_hash" ] &&
+        [ "$(sha256_file "$dir/$label.pid")" = "$pid_hash" ] || return 1
+      case "$variant" in
+        outside-root) grep -q 'retained unsafe handoff path' "$dir/launch.err" || return 1 ;;
+        symlink) [ -L "$handoff" ] && [ "$(readlink "$handoff")" = "$target" ] || return 1 ;;
+        unknown-entry) [ "$(cat "$handoff/unknown-entry")" = protected ] || return 1 ;;
+        sentinel-run-mismatch) grep -q 'retained invalid_sentinel' "$dir/launch.err" || return 1 ;;
+        fifo-type-mismatch) [ -f "$handoff/launcher-to-monitor.fifo" ] || return 1 ;;
+      esac
+    fi
+    rm -rf "$probe"; [ -L "$handoff" ] && rm -f "$handoff" || rm -rf "$handoff"; rm -rf "$target" "$dir"
+  done
+)
+
+check_abnormal_cleanup_fixture() {
+  local file="$1" id expected count=0
+  while IFS=$'\t' read -r id expected; do
+    [ "$id" = case_id ] && continue
+    count=$((count + 1)); [ -n "$expected" ] || return 1
+    case "$id" in
+      stale-detach-and-sync-owner|live-sync-collision|stale-reaper-lock-timeout|force-orphan-peer-isolation|setup-term-readiness-sentinel|partial-handoff-safe-cleanup) : ;;
+      *) return 1 ;;
+    esac
+  done < "$file"
+  [ "$count" -eq 6 ]
+}
+
+case_abnormal_cleanup_real_filesystem() {
+  local fixture="$FIXTURE_DIR/abnormal-cleanup-cases.tsv" id expected bad
+  check_abnormal_cleanup_fixture "$fixture" || die 'abnormal cleanup fixture rejected'
+  bad="$(mktemp "${TMPDIR:-/tmp}/agent-delegate-abnormal.XXXXXX")"
+  awk 'BEGIN{FS=OFS="\t"} NR==2{$NF=""} {print}' "$fixture" > "$bad"
+  if check_abnormal_cleanup_fixture "$bad"; then rm -f "$bad"; die 'abnormal cleanup checker accepted an empty expectation'; fi
+  rm -f "$bad"
+  while IFS=$'\t' read -r id expected; do
+    [ "$id" = case_id ] && continue
+    case "$id" in
+      stale-detach-and-sync-owner) run_stale_detach_and_sync_owner || die "$id failed" ;;
+      live-sync-collision) run_live_sync_collision || die "$id failed" ;;
+      stale-reaper-lock-timeout) run_stale_reaper_lock_timeout || die "$id failed" ;;
+      force-orphan-peer-isolation) run_force_orphan_peer_isolation || die "$id failed" ;;
+      setup-term-readiness-sentinel) run_setup_term_readiness_sentinel || die "$id failed" ;;
+      partial-handoff-safe-cleanup) run_partial_handoff_safe_cleanup || die "$id failed" ;;
+    esac
+  done < "$fixture"
+}
+
 case_heartbeat_schema_and_pids() { run_basic_harness_case "$1" done done 2; }
 
 case_heartbeat_timing_contract() {
@@ -1201,9 +1526,9 @@ write_repeat_manifest() {
     --arg fixture "$fixture_hash" --arg harness "$harness_hash" --argjson beats "$CURRENT_HEARTBEATS" \
     --argjson terminals "$CURRENT_TERMINALS" '
     {iteration:$iteration,commit:$commit,hashes:{runner:$runner,fixture:$fixture,harness:$harness},
-     case_count:24,exit_code:0,heartbeat_updates:$beats,terminal_reports:$terminals,runtime_residue:false}
+     case_count:25,exit_code:0,heartbeat_updates:$beats,terminal_reports:$terminals,runtime_residue:false}
   ' > "$out"
-  jq -e '.case_count==24 and .exit_code==0 and .heartbeat_updates>=2 and .terminal_reports>=1 and .runtime_residue==false' "$out" >/dev/null
+  jq -e '.case_count==25 and .exit_code==0 and .heartbeat_updates>=2 and .terminal_reports>=1 and .runtime_residue==false' "$out" >/dev/null
 }
 
 if [ -n "$RUN_CASE" ]; then
@@ -1235,12 +1560,12 @@ done
 if [ "$REPEAT" -eq 3 ]; then
   aggregate="$repeat_root/aggregate.json"
   jq -n --argjson repeats "$REPEAT" --arg commit "$(git -C "$REPO_ROOT" rev-parse HEAD)" \
-    '{commit:$commit,repeats:$repeats,registered_cases:25,passed_cases:25,failed_cases:0,
+    '{commit:$commit,repeats:$repeats,registered_cases:26,passed_cases:26,failed_cases:0,
       meta_cases:["readonly-gate-evidence","all-repeat-3"]}' > "$aggregate"
-  jq -e '.repeats==3 and .registered_cases==25 and .passed_cases==25 and .failed_cases==0' "$aggregate" >/dev/null
+  jq -e '.repeats==3 and .registered_cases==26 and .passed_cases==26 and .failed_cases==0' "$aggregate" >/dev/null
   printf 'PASS\tall-repeat-3\n'
   printf 'AGGREGATE\t%s\n' "$(jq -c . "$aggregate")"
-  printf 'ALL_PASS\trepeats=%s\tcases=25/25\n' "$REPEAT"
+  printf 'ALL_PASS\trepeats=%s\tcases=26/26\n' "$REPEAT"
 else
-  printf 'ALL_PASS\trepeats=%s\tcases=24/25\tmeta=all-repeat-3-deferred\n' "$REPEAT"
+  printf 'ALL_PASS\trepeats=%s\tcases=25/26\tmeta=all-repeat-3-deferred\n' "$REPEAT"
 fi


### PR DESCRIPTION
## 概要

owner、monitor、peer CLI が異常終了した後も、同じ label の次回 run が古い所有権と出力を安全に回収できるようにします。

Issue #92 の六つの follow-up finding を修正し、実 filesystem と実 process group を使う tracked test を追加しました。

## 原因

stale reaper は、pid と handoff directory が残る detach run だけを回収対象にしていました。

そのため、handoff directory が消えた detach owner と、`kill -9` で停止した sync owner は残り続けました。

peer CLI は label 共有の stdout と last-message へ直接書いていたため、monitor と worker の停止後に残った旧 peer が新 run の出力を上書きできました。

setup 中の signal trap と owner lock timeout の変換も不足しており、readiness sentinel を残せない経路と、公開契約にない exit 1 がありました。

## 変更内容

- stale detach owner と stale sync owner を、owner、PID、lease、handoff path の関係を確認して回収します。
- live sync collision と owner lock timeout を exit 2 で終了し、共有成果物を変更しません。
- peer の stdout と last-message を run 固有ファイルへ書き、owner が一致する場合だけ共有パスへ公開します。
- `--force` は stale owner を削除する前に旧 process group を確認し、残った peer CLI を停止します。
- setup 完了前の TERM、INT、HUP で `failure_stage: readiness_timeout` を含む sentinel を残します。
- sentinel に列挙された FIFO が既に消えていても、安全条件を満たす handoff directory を回収します。
- 日英の公開契約を、stale sync、missing handoff、lock timeout、orphan peer の規則に合わせて更新します。
- 六つの異常経路と owner、run、path、file type を壊した負例を、tracked real-filesystem harness で検証します。

## 影響

同じ label の次回 run は、異常終了した旧 run の共有 owner と出力を引き継がずに開始できます。

root 外の path、symlink、unknown entry、run ID や PID が一致しない資産は削除しません。

## 検証

- `spec-review` Iteration 2: PASS、指摘 0件
- `spec-test` T092: PASS
- `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --all`: `ALL_PASS repeats=1 cases=25/26 meta=all-repeat-3-deferred`
  - `all-repeat-3` は `--all` の再帰を避けるため runner が defer する meta case です。
- 新規 `abnormal-cleanup-real-filesystem`: PASS
- `bash -n`: PASS
- `git diff --check`: PASS
- `check_skill_quality.sh`: PASS

## 関連

Closes #92
