### PR TITLE
test(agent-delegate): 文書契約のmutation検証を強化する

### DIFF
--- a/skills/agent-delegate/references/scripts/tests/fixtures/document-contract.tsv
+++ b/skills/agent-delegate/references/scripts/tests/fixtures/document-contract.tsv
@@ -1,12 +1,12 @@
-contract_id	english_token	japanese_token	expected_value
-write-delegate	--detach	--detach	--detach
-sync-scope	read-only	読み取り専用	5
-polling	15 seconds	15秒	30
-reevaluation	30 minutes	30分	2
-hard-stop	2 hours	2時間	TERM
-termination-grace	90 seconds	90秒	terminal report
-automatic-force	--force	--force	--force
-heartbeat-interval	30 seconds	30秒	90
-watchdog	expected-run	expected-run	heartbeat
-runtime-records	*/*-heartbeat.json	*/*-heartbeat.json	*/*-owner.lock/
-runtime-record-files	*-heartbeat.json	*-heartbeat.json	*-owner.lock/
+contract_id	english_token	japanese_token	english_expected	japanese_expected
+write-delegate	--detach	--detach	expected run	expected run
+sync-scope	read-only	読み取り専用	5 minutes	5分
+polling	15 seconds	15秒	30 seconds	30秒
+reevaluation	30 minutes	30分	2 hours	2時間
+hard-stop	2 hours	2時間	TERM	TERM
+termination-grace	90 seconds	90秒	terminal report	terminal report
+automatic-force	--force	--force	TERM	TERM
+heartbeat-interval	30 seconds	30秒	90 seconds	90秒
+watchdog	expected-run	expected-run	heartbeat	heartbeat
+runtime-records	*/*-heartbeat.json	*/*-heartbeat.json	*/*-owner.lock/	*/*-owner.lock/
+runtime-record-files	*-heartbeat.json	*-heartbeat.json	*-owner.lock/	*-owner.lock/

--- a/skills/agent-delegate/references/scripts/tests/run_tests.sh
+++ b/skills/agent-delegate/references/scripts/tests/run_tests.sh
@@ -243,8 +243,8 @@ corrupt_fixture_expectation() {
 }
 
 check_wait_contract_docs() {
-  local fixture="$FIXTURE_DIR/document-contract.tsv" id en ja expected
-  while IFS=$'\t' read -r id en ja expected; do
+  local fixture="$FIXTURE_DIR/document-contract.tsv" id en ja en_expected ja_expected
+  while IFS=$'\t' read -r id en ja en_expected ja_expected; do
     case "$id" in
       reevaluation|hard-stop|termination-grace|automatic-force)
         grep -Fq -- "$en" "$REPO_ROOT/skills/agent-delegate/references/contract.md" || return 1
@@ -987,8 +987,8 @@ case_heartbeat_testmode_both_directions() {
 
 document_contract_targets() {
   cat <<'EOF'
-T-A13	en	README.md	write-delegate,polling,reevaluation,hard-stop,termination-grace,automatic-force,heartbeat-interval
-T-A13	ja	README.ja.md	write-delegate,polling,reevaluation,hard-stop,termination-grace,automatic-force,heartbeat-interval
+T-A13	en	README.md	write-delegate,polling,reevaluation,hard-stop,termination-grace,automatic-force
+T-A13	ja	README.ja.md	write-delegate,polling,reevaluation,hard-stop,termination-grace,automatic-force
 T-A11	en	skills/agent-delegate/SKILL.md	write-delegate
 T-A12	en	skills/agent-delegate/references/contract.md	sync-scope,polling,reevaluation,hard-stop,termination-grace,automatic-force,heartbeat-interval
 T-A12	ja	skills/agent-delegate/references/contract.ja.md	sync-scope,polling,reevaluation,hard-stop,termination-grace,automatic-force,heartbeat-interval
@@ -1023,38 +1023,70 @@ contract_fixture_row() {
 }
 
 check_contract_fixture() {
-  local file="$1" id en ja expected count=0
-  [ "$(awk -F '\t' 'NR==1 {print NF}' "$file")" -eq 4 ] || return 1
-  while IFS=$'\t' read -r id en ja expected; do
-    [ "$id" = contract_id ] && continue
-    count=$((count + 1))
-    [ -n "$id" ] && [ -n "$en" ] && [ -n "$ja" ] && [ -n "$expected" ] || return 1
-    [ "$(awk -F '\t' -v wanted="$id" 'NR>1 && $1==wanted {count++} END {print count+0}' "$file")" -eq 1 ] || return 1
-  done < "$file"
-  [ "$count" -gt 0 ]
+  local file="$1"
+  awk -F '\t' '
+    NR==1 {
+      if ($0 != "contract_id\tenglish_token\tjapanese_token\tenglish_expected\tjapanese_expected") exit 1
+      next
+    }
+    NF!=5 || $1=="" || $2=="" || $3=="" || $4=="" || $5=="" ||
+      $4~/^[0-9]+$/ || $5~/^[0-9]+$/ || seen[$1]++ {exit 1}
+    {count++}
+    END {if (count==0) exit 1}
+  ' "$file"
 }
 
 check_document_contract_targets() {
-  local fixture="$1" test_id language relative ids row id en ja expected token count=0
+  local fixture="$1" wanted_test="$2" test_id language relative ids row id
+  local en ja en_expected ja_expected token expected expected_count count=0
   document_contract_targets | awk -F '\t' '
     NF!=4 || ($1!="T-A11" && $1!="T-A12" && $1!="T-A13") || ($2!="en" && $2!="ja") || seen[$3]++ {exit 1}
     END {if (NR!=24) exit 1}
   ' || return 1
+  case "$wanted_test" in
+    T-A11) expected_count=11 ;;
+    T-A12) expected_count=6 ;;
+    T-A13) expected_count=7 ;;
+    *) return 1 ;;
+  esac
   while IFS=$'\t' read -r test_id language relative ids; do
+    [ "$test_id" = "$wanted_test" ] || continue
     count=$((count + 1))
     [ -f "$REPO_ROOT/$relative" ] || return 1
     while [ -n "$ids" ]; do
       case "$ids" in *,*) id="${ids%%,*}"; ids="${ids#*,}" ;; *) id="$ids"; ids="" ;; esac
       row="$(contract_fixture_row "$fixture" "$id")" || return 1
-      IFS=$'\t' read -r id en ja expected <<EOF
+      IFS=$'\t' read -r id en ja en_expected ja_expected <<EOF
 $row
 EOF
-      if [ "$language" = en ]; then token="$en"; else token="$ja"; fi
-      grep -Fq -- "$token" "$REPO_ROOT/$relative" || return 1
-      grep -Fq -- "$expected" "$REPO_ROOT/$relative" || return 1
+      if [ "$language" = en ]; then
+        token="$en"; expected="$en_expected"
+      else
+        token="$ja"; expected="$ja_expected"
+      fi
+      check_contract_section "$REPO_ROOT/$relative" "$token" "$expected" || return 1
     done
   done < <(document_contract_targets)
-  [ "$count" -eq 24 ]
+  [ "$count" -eq "$expected_count" ]
+}
+
+check_contract_section() {
+  local file="$1" token="$2" expected="$3"
+  awk -v token="$token" -v expected="$expected" '
+    function matches(section) {
+      gsub(/[[:space:]]+/, " ", section)
+      return index(section, token) && index(section, expected)
+    }
+    /^#+[[:space:]]/ {
+      if (matches(section)) found=1
+      section=""
+    }
+    {section=section " " $0}
+    END {
+      if (matches(section)) found=1
+      exit !found
+    }
+  ' "$file"
 }
 
 check_ordered_tokens() {
@@ -1083,24 +1115,51 @@ check_runtime_record_order() {
 }
 
 check_document_contracts() {
-  local fixture="$1"
+  local fixture="$1" test_id="$2"
   check_contract_fixture "$fixture" &&
-    check_document_contract_targets "$fixture" &&
-    check_runtime_record_order
+    check_document_contract_targets "$fixture" "$test_id" &&
+    { [ "$test_id" != T-A13 ] || check_runtime_record_order; }
+}
+
+check_contract_mutation_rejected() {
+  local fixture="$1" test_id="$2" mutation_id="$3" language="$4" kind="$5" replacement="$6"
+  local field bad
+  case "$language:$kind" in
+    en:token) field=2 ;;
+    ja:token) field=3 ;;
+    en:expected) field=4 ;;
+    ja:expected) field=5 ;;
+    *) return 1 ;;
+  esac
+  bad="$(mktemp "$(cd "${TMPDIR:-/tmp}" && pwd)/agent-delegate-contract.XXXXXX")"
+  awk -v wanted="$mutation_id" -v field="$field" -v replacement="$replacement" '
+    BEGIN {FS=OFS="\t"}
+    $1==wanted {$field=replacement; changed++}
+    {print}
+    END {if (changed!=1) exit 1}
+  ' "$fixture" > "$bad" || { rm -f "$bad"; return 1; }
+  if check_document_contracts "$bad" "$test_id"; then rm -f "$bad"; return 1; fi
+  rm -f "$bad"
 }
 
 check_contract_positive_and_negative() {
-  local mutation_id="$1" fixture="$FIXTURE_DIR/document-contract.tsv" bad
-  check_document_contracts "$fixture" || return 1
-  bad="$(mktemp "$(cd "${TMPDIR:-/tmp}" && pwd)/agent-delegate-contract.XXXXXX")"
-  awk -v wanted="$mutation_id" 'BEGIN{FS=OFS="\t"} $1==wanted{$NF="__missing_contract_value__"} {print}' \
-    "$fixture" > "$bad"
-  if check_document_contracts "$bad"; then rm -f "$bad"; return 1; fi
-  rm -f "$bad"
+  local test_id="$1" token_id="$2" token_language="$3" time_id="$4" time_language="$5" time_replacement="$6"
+  local fixture="$FIXTURE_DIR/document-contract.tsv"
+  check_document_contracts "$fixture" "$test_id" || return 1
+  check_contract_mutation_rejected "$fixture" "$test_id" "$token_id" "$token_language" token \
+    __missing_contract_token__ || return 1
+  [ -z "$time_id" ] || check_contract_mutation_rejected "$fixture" "$test_id" "$time_id" \
+    "$time_language" expected "$time_replacement"
 }
-case_write_delegate_docs_use_detach() { check_contract_positive_and_negative write-delegate; }
-case_caller_sync_poll_timeout_contract() { check_contract_positive_and_negative polling; }
-case_bilingual_contract_and_runtime_records() { check_contract_positive_and_negative runtime-record-files; }
+case_write_delegate_docs_use_detach() {
+  check_contract_positive_and_negative T-A11 write-delegate en '' '' ''
+}
+case_caller_sync_poll_timeout_contract() {
+  check_contract_positive_and_negative T-A12 polling en heartbeat-interval en '91 seconds'
+}
+case_bilingual_contract_and_runtime_records() {
+  check_contract_positive_and_negative T-A13 runtime-record-files ja polling ja '31秒'
+}
 
 check_compatibility_fixture() {
   local file="$1" id path ref mode target sandbox stub expected_exit expected_status artifact count=0


### PR DESCRIPTION
## 概要

Issue #108の文書契約テストを強化した。

fixtureの期待値を日英別に分け、トークンと単位付き期待値が同じMarkdown節にある場合だけ合格させる。

## 変更内容

- `document-contract.tsv`を5列へ変更し、日英それぞれの期待値を持たせた。
- 裸の数値を期待値として登録できない検査を追加した。
- T-A11、T-A12、T-A13が自分の対象文書だけを検査するように分けた。
- 日英のトークン列mutationと時間契約mutationを、正例と同じ検査関数へ渡して拒否を確認した。
- READMEにはheartbeatの更新間隔と鮮度が書かれていないため、別契約の数値へ偶然一致していた`heartbeat-interval`の割当てを外した。
- productionの`agent-delegate.sh`は変更していない。

## 検証

- T-A11、T-A12、T-A13の個別実行: 3/3 PASS
- 3ケースのdry-run: PASS
- `run_tests.sh --all --repeat 3`: 3回とも26/26 PASS、合計78/78
- `bash -n skills/agent-delegate/references/scripts/tests/run_tests.sh`: PASS
- `git diff --check`: PASS
- `git diff --check origin/main...HEAD`: PASS

独立したspec-test担当もcommit `4e7308f`を検証し、Gate PASSと判定した。

## レビュー

Claudeのread-onlyレビューは、Critical 0件、Improvement 2件、Minor 3件だった。

`fix_before: implementation`は0件で、GateはPASS。

最初の同期レビューは5分以内に終わらず、停止時に最終メッセージがなかったため`malformed_output`になった。

次のdetachレビューは構造化レビューを完成させたが、monitorが公開直前にTERMを受け、reportだけが`env_error`になった。

同じcommitと完成済みレビュー本文を対象に短い確認レビューを新規runで実行し、`status: done`、read-only、Gate PASSのterminal reportを取得した。

着地を止めない2件の`fix_before: follow_up`はIssue #111へまとめた。

## 関連

Closes #108

Follow-up: #111