### PR TITLE
test(agent-delegate): cover CommonMark fence boundaries

### DIFF
--- a/skills/agent-delegate/references/scripts/tests/run_tests.sh
+++ b/skills/agent-delegate/references/scripts/tests/run_tests.sh
@@ -1192,7 +1192,23 @@ check_contract_section() {
       while (substr(line, count + 1, 1) == marker) count++
       return count
     }
+    function opening_fence_indent_ok(line, i, char, spaces) {
+      spaces=0
+      for (i=1; i<=length(line); i++) {
+        char=substr(line, i, 1)
+        if (char == " ") {
+          spaces++
+          if (spaces > 3) return 0
+        } else if (char == "\t") {
+          return 0
+        } else {
+          break
+        }
+      }
+      return 1
+    }
     {
+      opening_indent_ok=opening_fence_indent_ok($0)
       trimmed=$0
       sub(/^[[:space:]]*/, "", trimmed)
       marker=substr(trimmed, 1, 1)
@@ -1203,7 +1219,7 @@ check_contract_section() {
         if (marker == fence_marker && run_length >= fence_length && rest ~ /^[[:space:]]*$/) {
           in_fence=0
         }
-      } else if ((marker == "`" || marker == "~") && run_length >= 3) {
+      } else if (opening_indent_ok && (marker == "`" || marker == "~") && run_length >= 3) {
         in_fence=1
         fence_marker=marker
         fence_length=run_length
@@ -1221,19 +1237,38 @@ check_contract_section() {
 }
 
 check_contract_section_fence_regression() {
-  local dir positive negative
+  local dir positive three_space_positive negative long_closing_negative indented_negative
+  local tab_indented_negative candidate
   dir="$(new_work_dir)"
   positive="$dir/fenced-comments.md"
+  three_space_positive="$dir/three-space-opening.md"
   negative="$dir/real-heading.md"
+  long_closing_negative="$dir/long-closing-fence.md"
+  indented_negative="$dir/indented-code-block.md"
+  tab_indented_negative="$dir/tab-indented-code-block.md"
   cat > "$positive" <<'EOF'
 # Contract
 write-delegate
-```sh
-# This shell comment is not a Markdown heading.
-```
-~~~sh
-# This shell comment is also not a Markdown heading.
+   ```sh
 ~~~
+# This shell comment is not a Markdown heading.
+```js
+# A fence marker with trailing content does not close the block.
+   ````
+~~~sh
+```
+# This shell comment is also not a Markdown heading.
+~~~js
+# A tilde fence marker with trailing content does not close the block.
+~~~~
+delegate request
+EOF
+  cat > "$three_space_positive" <<'EOF'
+# Contract
+write-delegate
+   ```sh
+# This shell comment is not a Markdown heading.
+   ```
 delegate request
 EOF
   cat > "$negative" <<'EOF'
@@ -1242,14 +1277,39 @@ write-delegate
 # Separate contract
 delegate request
 EOF
+  cat > "$long_closing_negative" <<'EOF'
+# Contract
+write-delegate
+```sh
+# This shell comment is not a Markdown heading.
+````
+# Separate contract
+delegate request
+EOF
+  cat > "$indented_negative" <<'EOF'
+# Contract
+write-delegate
+    ```sh
+# Separate contract
+delegate request
+EOF
+  printf '# Contract\nwrite-delegate\n\t```sh\n# Separate contract\ndelegate request\n' \
+    > "$tab_indented_negative"
   check_contract_section "$positive" write-delegate 'delegate request' || {
     rm -rf "$dir"
     return 1
   }
-  if check_contract_section "$negative" write-delegate 'delegate request'; then
+  check_contract_section "$three_space_positive" write-delegate 'delegate request' || {
     rm -rf "$dir"
     return 1
-  fi
+  }
+  for candidate in "$negative" "$long_closing_negative" "$indented_negative" \
+    "$tab_indented_negative"; do
+    if check_contract_section "$candidate" write-delegate 'delegate request'; then
+      rm -rf "$dir"
+      return 1
+    fi
+  done
   rm -rf "$dir"
 }
 


### PR DESCRIPTION
## 概要

`check_contract_section`がMarkdownのfenceを判定するとき、opening fenceの行頭インデントを確認するようにしました。
行頭0から3スペースはopening fenceとして受理し、4スペース以上またはタブで始まる行はindented code blockとして扱います。

回帰検査には、長いclosing fence、異なるmarker、marker後の文字、行頭3スペース、行頭4スペース、行頭タブのケースを追加しました。
すべて既存の`check_contract_section`を通して検査します。

## 原因

従来の判定は、行頭の空白をすべて取り除いてからfence markerを調べていました。
そのため、CommonMarkではindented code blockになる4スペース以上の行もopening fenceとして記録し、後続の実見出しをfence内として無視する可能性がありました。

## 影響

変更対象は`agent-delegate`のテストハーネスだけです。
本番スクリプトや公開契約は変更しません。

契約文書へインデント付きのfence例を追加しても、節検査が実見出しを誤って結合しにくくなります。

## 検証

- [x] T-A11 `write-delegate-docs-use-detach`
- [x] T-A12 `caller-sync-poll-timeout-contract`
- [x] T-A13 `bilingual-contract-and-runtime-records`
- [x] `run_tests.sh --all --repeat 3`（81/81 PASS）
- [x] skill quality（4スキル）
- [x] `bash -n`
- [x] `git diff --check`

## レビュー

Claudeの初回read-onlyレビューは、3スペースopeningの正例が後続のtilde fenceに救済される問題を1件指摘し、Gate FAILでした。
専用の3スペース正例へ分離し、行頭タブの負例も追加しました。

修正後の再レビューは`fix_before: implementation`が0件で、再計算したGateはPASSです。
実行環境がClaude完了直後にreportを`blocked/env_error`として回収したため、起動前に宣言した成果物の新規生成、expected run相関、4点構造、`fix_before`、Gate、read-only fingerprintを検証してレビュー結果を採用しました。

## 対象外

4スペース以上でインデントされたclosing fenceを拒否する変更は含めません。
該当判定は今回の差分以前から存在し、Issue #113の完了条件はopening fenceの境界に限定されています。

## 関連

Closes #113
