### PR TITLE
fix(agent-delegate): monitor TERM時に完了済みreviewを回収する

### DIFF
--- a/skills/agent-delegate/references/contract.ja.md
+++ b/skills/agent-delegate/references/contract.ja.md
@@ -296,6 +296,9 @@ stale-reaper が期限内に owner lock を取得できない場合、新しい 
 - ラッパーは相手完了時に `report.json` をアトミックに書く。相手が report を書かずに殺された
   場合は、ラッパー自身が `blocked` の report（`blocker_category: env_error`）を合成する。
   呼び出し元にスキーマ再実装をさせない。
+- monitor が `TERM`、`INT`、`HUP` を受けた場合、または異常終了した場合は、worker の process group を停止してから終了処理を行う。
+  未公開の review candidate を `done` として採用できるのは、expected run に属し、blocker のない `review` 結果で、`touchedFiles` が空、成果物パスが宣言どおり、review の構造が正しく、同じ run の final message とバイト単位で一致する場合だけである。
+  成果物が欠落、不正、古い、別 run、delegate mode、または検証不能の場合は candidate を破棄し、`blocked` / `env_error` に置き換える。
 
 ### ポーリングと expected run の状態
 
@@ -349,7 +352,8 @@ validな待機状態なら、呼び出し側は再評価後も待機を続ける
 
 1. 呼び出し側はreportから状態をもう一度確認し、新しいterminal report、`SUPERSEDED`、`DEAD`のいずれかを確認した場合はシグナルを送らず、その状態を返す。
 2. expected runのownerが変わっておらず、そのmonitorが生存している場合は、呼び出し側がmonitorへ`TERM`を送る。
-   monitorはworkerとpeerを停止し、expected runの`blocked` reportとterminal heartbeatを公開してから、ownerなどの実行時ファイルを削除する。
+   monitorはworkerとpeerを停止し、expected runのterminal reportとterminal heartbeatを公開してから、ownerなどの実行時ファイルを削除する。
+   完了済みreviewを`done`として公開できるのは、上記のfail-closedなcandidate検証をすべて満たす場合だけであり、それ以外の中断runは`blocked` / `env_error`として公開する。
 3. 呼び出し側はreportを先に確認するポーリングを最大90秒続け、valid terminal reportが公開されたら採用する。
 4. 2時間到達時にmonitorが不在または生存不明の場合、あるいは90秒以内にterminal reportが公開されない場合は、呼び出し側が待機を終了する。
    呼び出し側はrun id、最後に読めたowner、pid、heartbeat、プロセス確認結果、report検証エラーを人間へ渡す。

--- a/skills/agent-delegate/references/contract.md
+++ b/skills/agent-delegate/references/contract.md
@@ -357,6 +357,14 @@ bound by the host command's execution limit.
   peer is killed and never writes one, the monitor synthesizes a `blocked`
   report (`blocker_category: env_error`) itself, so callers never re-implement
   the schema.
+- If the monitor receives `TERM`, `INT`, or `HUP`, or exits unexpectedly, it
+  stops the worker process group before finalization. It promotes an unpublished
+  review candidate to `done` only when the candidate belongs to the expected
+  run, is a blocker-free `review` result with empty `touchedFiles`, declares the
+  expected artifact paths, contains a structurally valid review, and that review
+  is byte-identical to the same run's final message. Missing, malformed, stale,
+  wrong-run, delegate-mode, or otherwise unverified candidates are discarded and
+  replaced with `blocked` / `env_error`.
 
 ### Polling and expected-run state
 
@@ -422,8 +430,10 @@ At 2 hours, the caller performs one final report-first state evaluation:
    sending a signal.
 2. If the expected-run owner still matches and its monitor is alive, send
    `TERM` to that monitor. The monitor terminates the worker and peer, publishes
-   an expected-run `blocked` report and terminal heartbeat, and removes runtime
-   owner records.
+   an expected-run terminal report and terminal heartbeat, and removes runtime
+   owner records. A fully completed review may be published as `done` only under
+   the fail-closed candidate checks above; every other interrupted run is
+   published as `blocked` / `env_error`.
 3. Continue report-first polling for up to 90 seconds. Accept a valid terminal
    report if it appears.
 4. If the monitor is absent or unknown at the 2-hour limit, or no terminal

--- a/skills/agent-delegate/references/scripts/agent-delegate.sh
+++ b/skills/agent-delegate/references/scripts/agent-delegate.sh
@@ -256,6 +256,26 @@ utc_now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
 heartbeat_test_mode() { [ "${AGENT_DELEGATE_TEST_MODE:-0}" = heartbeat ]; }
 owner_lock_signal_test_mode() { [ "${AGENT_DELEGATE_TEST_MODE:-0}" = owner-lock-signal ]; }
+monitor_term_recovery_test_mode() { [ "${AGENT_DELEGATE_TEST_MODE:-0}" = monitor-term-recovery ]; }
+
+monitor_term_recovery_test_hook() {
+  local ready_file="${AGENT_DELEGATE_TEST_MONITOR_BEFORE_PUBLISH_READY_FILE:-}"
+  local release_file="${AGENT_DELEGATE_TEST_MONITOR_BEFORE_PUBLISH_RELEASE_FILE:-}" deadline
+  monitor_term_recovery_test_mode || return 0
+  [ -n "$ready_file" ] && [ -n "$release_file" ] || {
+    err "monitor TERM recovery test paths are required"
+    return 1
+  }
+  : > "$ready_file"
+  deadline=$((SECONDS + 10))
+  while [ ! -f "$release_file" ]; do
+    [ "$SECONDS" -lt "$deadline" ] || {
+      err "monitor TERM recovery test release timeout"
+      return 1
+    }
+    sleep 0.01
+  done
+}
 
 owner_lock_signal_test_hook() {
   local stage="$1" configured="${AGENT_DELEGATE_TEST_OWNER_LOCK_SIGNAL_STAGE:-}"
@@ -1454,11 +1474,33 @@ run_delegate() {
 }
 
 # --- review mode (§4.4) ----------------------------------------------------
-#
+
+review_structure_error() {
+  local review_file="$1" missing=() joined="" item
+  grep -q '^type: review'                         "$review_file" || missing+=("type: review")
+  grep -q '^## Meta'                              "$review_file" || missing+=("## Meta")
+  grep -q '^## Findings'                          "$review_file" || missing+=("## Findings")
+  grep -q '^### Critical'                         "$review_file" || missing+=("### Critical")
+  grep -q '^### Improvement'                      "$review_file" || missing+=("### Improvement")
+  grep -q '^### Minor'                            "$review_file" || missing+=("### Minor")
+  grep -q '^## Summary'                           "$review_file" || missing+=("## Summary")
+  grep -qE 'Gate:[[:space:]]*(PASS|FAIL)'         "$review_file" || missing+=("Gate: PASS|FAIL")
+  [ "${#missing[@]}" -gt 0 ] || return 0
+
+  # Join with ", " manually: parameter expansion with IFS uses only the first
+  # IFS char as the separator, so "IFS=', '" would yield comma-only joins.
+  for item in "${missing[@]}"; do
+    if [ -z "$joined" ]; then joined="$item"; else joined="$joined, $item"; fi
+  done
+  printf 'review output malformed: missing %s' "$joined"
+  return 1
+}
+
 # Always read-only. Prompt = adversarial template + caller context. The reviewer
-# emits the full review file as its final message; we verify 4 structural points
-# then persist it. read-only that still touched files (after excluding our own
-# artifacts) is a sandbox misconfiguration, surfaced as sandbox_violation.
+# emits the full review file as its final message; we verify the required
+# structure and then persist it. read-only that still touched files (after
+# excluding our own artifacts) is a sandbox misconfiguration, surfaced as
+# sandbox_violation.
 run_review() {
   local template="${REFERENCES_DIR}/adversarial-review-prompt.md"
   if [ "${AGENT_DELEGATE_REVIEW_LANG:-en}" = "ja" ] && [ -f "${REFERENCES_DIR}/adversarial-review-prompt.ja.md" ]; then
@@ -1487,27 +1529,10 @@ run_review() {
     return
   fi
 
-  # Machine-verify the 4 contract points on the final message.
-  local missing=()
-  grep -q '^type: review'                         "$RUN_LAST_MSG_FILE" || missing+=("type: review")
-  grep -q '^## Meta'                              "$RUN_LAST_MSG_FILE" || missing+=("## Meta")
-  grep -q '^## Findings'                          "$RUN_LAST_MSG_FILE" || missing+=("## Findings")
-  grep -q '^### Critical'                         "$RUN_LAST_MSG_FILE" || missing+=("### Critical")
-  grep -q '^### Improvement'                      "$RUN_LAST_MSG_FILE" || missing+=("### Improvement")
-  grep -q '^### Minor'                            "$RUN_LAST_MSG_FILE" || missing+=("### Minor")
-  grep -q '^## Summary'                           "$RUN_LAST_MSG_FILE" || missing+=("## Summary")
-  grep -qE 'Gate:[[:space:]]*(PASS|FAIL)'         "$RUN_LAST_MSG_FILE" || missing+=("Gate: PASS|FAIL")
-
-  if [ "${#missing[@]}" -gt 0 ]; then
-    # Join with ", " manually: parameter expansion with IFS uses only the first
-    # IFS char as the separator, so "IFS=', '" would yield comma-only joins.
-    local joined=""
-    local item
-    for item in "${missing[@]}"; do
-      if [ -z "$joined" ]; then joined="$item"; else joined="$joined, $item"; fi
-    done
+  local structure_error=""
+  if ! structure_error="$(review_structure_error "$RUN_LAST_MSG_FILE")"; then
     REPORT_STATUS="blocked"
-    BLOCKER="review output malformed: missing $joined"
+    BLOCKER="$structure_error"
     BLOCKER_CATEGORY="malformed_output"
     write_report
     return
@@ -1669,6 +1694,23 @@ publish_worker_candidate() {
   publish_run_artifacts || return $?
   owner_publish_path "$RUN_ID" "$CANDIDATE_FILE" "$REPORT_FILE" 1 "$MONITOR_PID" || return $?
   printf '%s' "$status"
+}
+
+recoverable_review_candidate() {
+  [ "$MODE" = review ] && [ -f "$CANDIDATE_FILE" ] && [ -f "$REVIEW_FILE" ] &&
+    [ -f "$RUN_LAST_MSG_FILE" ] || return 1
+  jq -e \
+    --arg run_id "$RUN_ID" --arg review_file "$REVIEW_FILE" \
+    --arg last_message "$LAST_MSG_FILE" --arg stdout "$STDOUT_FILE" --arg stderr "$STDERR_FILE" '
+      .status=="done" and .blocker==null and .blocker_category==null and
+      .meta.run_id==$run_id and .meta.mode=="review" and
+      (.touchedFiles|type)=="array" and .touchedFiles==[] and
+      .artifacts.review_file==$review_file and
+      .artifacts.last_message==$last_message and
+      .artifacts.stdout==$stdout and .artifacts.stderr==$stderr
+    ' "$CANDIDATE_FILE" >/dev/null 2>&1 || return 1
+  review_structure_error "$REVIEW_FILE" >/dev/null || return 1
+  cmp -s "$RUN_LAST_MSG_FILE" "$REVIEW_FILE"
 }
 
 make_heartbeat_test_candidate() {
@@ -1889,13 +1931,20 @@ monitor_finalize_abnormal() {
   close_monitor_handoff_fds
 
   # A terminal report may already have won the race with the signal. Preserve
-  # it; otherwise replace any partial candidate with an owned blocked result.
+  # it. A completed read-only review candidate may also be promoted if every
+  # run-correlation and structure check passes; all other cases fail closed.
   if report_is_terminal_for_run "$REPORT_FILE" "$RUN_ID"; then
     terminal_status="$(jq -r '.status' "$REPORT_FILE")"
   elif owner_matches_run "$RUN_ID" && pid_matches_run "$RUN_ID" "$monitor_pid"; then
-    rm -f "$CANDIDATE_FILE" "$CANDIDATE_TMP"
-    if make_blocked_candidate "$reason"; then
+    if recoverable_review_candidate; then
+      err "publishing completed review after abnormal monitor termination"
       terminal_status="$(publish_worker_candidate)" || terminal_status=""
+    fi
+    if [ -z "$terminal_status" ]; then
+      rm -f "$CANDIDATE_FILE" "$CANDIDATE_TMP"
+      if make_blocked_candidate "$reason"; then
+        terminal_status="$(publish_worker_candidate)" || terminal_status=""
+      fi
     fi
   fi
   case "$worker_pid" in ''|*[!0-9]*) worker_pid="$monitor_pid" ;; esac
@@ -2014,6 +2063,7 @@ run_monitor() {
     err "worker (pid $worker_pid) exited rc=$worker_rc without report candidate"
     terminate_remaining_monitor_group
   fi
+  monitor_term_recovery_test_hook
   terminal_status="$(publish_worker_candidate)" || {
     err "failed to publish worker report candidate"
     owner_remove_runtime "$RUN_ID" 1 "$monitor_pid" || true

--- a/skills/agent-delegate/references/scripts/tests/fixtures/case-manifest.tsv
+++ b/skills/agent-delegate/references/scripts/tests/fixtures/case-manifest.tsv
@@ -26,3 +26,4 @@ T-A24	caller-state-priority	suite	state-fixture	caller-priority.tsv	priority-sta
 T-A25	caller-wait-upper-bound	suite	wait-bound-fixture	caller-wait-bounds.tsv	reevaluation-stop-and-escalation-decisions
 T-A26	abnormal-cleanup-real-filesystem	suite	abnormal-cleanup	abnormal-cleanup-cases.tsv	six-abnormal-cleanup-paths
 T-A27	artifact-recovery-contract	suite	artifact-recovery	artifact-recovery.tsv	recovery-decisions-and-public-docs
+T-A28	monitor-term-review-recovery	suite	monitor-term-recovery	monitor-term-review-cases.tsv	same-run-review-recovery-and-fail-closed-negatives

--- a/skills/agent-delegate/references/scripts/tests/fixtures/monitor-term-review-cases.tsv
+++ b/skills/agent-delegate/references/scripts/tests/fixtures/monitor-term-review-cases.tsv
@@ -1,0 +1,5 @@
+case_id	mutation	expected_status
+valid-same-run	none	done
+missing-review	missing-review	blocked
+malformed-review	malformed-review	blocked
+wrong-run	wrong-run	blocked

--- a/skills/agent-delegate/references/scripts/tests/run_tests.sh
+++ b/skills/agent-delegate/references/scripts/tests/run_tests.sh
@@ -1437,11 +1437,13 @@ cleanup_detach_stub_fixture() {
 
 launch_detach_review_stub() {
   local dir="$1" label="$2" barrier="$3" signal_stage="${4:-}" test_handoff="${5:-}"
+  local test_mode_override="${6:-}" term_ready_file="${7:-}" term_release_file="${8:-}"
   local driver driver_pgid monitor_mode=0 test_mode=0 ready_file=""
   if [ -n "$signal_stage" ]; then
     test_mode=owner-lock-signal
     ready_file="$barrier/claude.ready"
   fi
+  [ -z "$test_mode_override" ] || test_mode="$test_mode_override"
   case $- in *m*) monitor_mode=1 ;; esac
   set -m
   (
@@ -1450,6 +1452,8 @@ launch_detach_review_stub() {
       AGENT_DELEGATE_TEST_HANDOFF_DIR="$test_handoff" \
       AGENT_DELEGATE_TEST_OWNER_LOCK_SIGNAL_STAGE="$signal_stage" \
       AGENT_DELEGATE_TEST_OWNER_LOCK_READY_FILE="$ready_file" \
+      AGENT_DELEGATE_TEST_MONITOR_BEFORE_PUBLISH_READY_FILE="$term_ready_file" \
+      AGENT_DELEGATE_TEST_MONITOR_BEFORE_PUBLISH_RELEASE_FILE="$term_release_file" \
       bash "$SCRIPT" --mode review --prompt-file "$dir/prompt.md" \
         --out-dir "$dir" --label "$label" --target claude --detach
   ) > "$dir/$label-launch.out" 2> "$dir/$label-launch.err" &
@@ -1536,6 +1540,84 @@ run_detach_review_lifecycle_stub() (
   trap - EXIT TERM INT HUP
   rm -rf "$dir"
 )
+
+run_monitor_term_review_stub() (
+  local case_id="$1" mutation="$2" expected_status="$3" dir label barrier owner monitor worker peer
+  local handoff driver_pgid monitor_pgid worker_pgid run candidate review ready release deadline report
+  dir="$(new_work_dir)"; label="monitor-term-review-$case_id"; barrier="$dir/barrier"
+  ready="$barrier/candidate.ready"; release="$barrier/monitor.release"
+  trap 'touch "$release" 2>/dev/null || true; cleanup_detach_stub_fixture "$dir" "$label"' EXIT TERM INT HUP
+  mkdir "$barrier"; mkfifo "$barrier/release.fifo"; printf 'review prompt\n' > "$dir/prompt.md"
+  launch_detach_review_stub "$dir" "$label" "$barrier" "" "" monitor-term-recovery "$ready" "$release" || return 1
+  wait_for_detach_stub_runtime "$dir" "$label" "$barrier" || return 1
+  owner="$dir/$label-owner.json"; monitor="$(jq -r '.monitor_pid' "$owner")"; worker="$(jq -r '.worker_pid' "$owner")"
+  peer="$(cat "$barrier/claude.pid")"; handoff="$(jq -r '.handoff_dir' "$owner")"
+  driver_pgid="$(cat "$dir/$label-launcher-shell.pgid")"; monitor_pgid="$(process_group_of "$monitor")"
+  worker_pgid="$(process_group_of "$worker")"; run="$(jq -r '.run_id' "$owner")"
+  candidate="$dir/$label-report.candidate.$run.json"; review="$dir/$label-review.md"
+  [ -n "$monitor_pgid" ] && [ "$monitor_pgid" = "$worker_pgid" ] && [ "$monitor_pgid" != "$driver_pgid" ] || return 1
+  kill -TERM -- "-$driver_pgid" 2>/dev/null || true
+  kill -0 "$monitor" 2>/dev/null && kill -0 "$worker" 2>/dev/null || return 1
+
+  printf 'release\n' > "$barrier/release.fifo"
+  deadline=$(( $(date -u +%s) + 10 ))
+  while [ "$(date -u +%s)" -lt "$deadline" ]; do
+    [ -f "$ready" ] && [ -f "$candidate" ] && [ -f "$review" ] && break
+  done
+  [ -f "$ready" ] && [ -f "$candidate" ] && [ -f "$review" ] || return 1
+  ! kill -0 "$peer" 2>/dev/null || return 1
+
+  case "$mutation" in
+    none) : ;;
+    missing-review) rm -f "$review" ;;
+    malformed-review) printf 'type: review\n## Findings\n' > "$review" ;;
+    wrong-run)
+      jq '.meta.run_id="stale-run"' "$candidate" > "$candidate.tmp" && mv -f "$candidate.tmp" "$candidate"
+      ;;
+    *) return 1 ;;
+  esac
+  kill -TERM "$monitor" 2>/dev/null || return 1
+  wait_for_detach_stub_terminal "$dir" "$label" "$expected_status" "$handoff" || return 1
+  report="$dir/$label-report.json"
+  if [ "$expected_status" = done ]; then
+    jq -e --arg run "$run" --arg review "$review" \
+      '.status=="done" and .blocker==null and .blocker_category==null and
+       .meta.run_id==$run and .meta.mode=="review" and .touchedFiles==[] and
+       .artifacts.review_file==$review' "$report" >/dev/null || return 1
+    grep -q '^type: review' "$review" && grep -q '^## Meta' "$review" &&
+      grep -q '^## Findings' "$review" && grep -qE 'Gate:[[:space:]]*(PASS|FAIL)' "$review" || return 1
+  else
+    jq -e --arg run "$run" \
+      '.status=="blocked" and .blocker_category=="env_error" and
+       .meta.run_id==$run and (.blocker|contains("TERM"))' "$report" >/dev/null || return 1
+  fi
+  [ ! -e "$candidate" ] && [ ! -e "$candidate.tmp" ] || return 1
+  trap - EXIT TERM INT HUP
+  rm -rf "$dir"
+)
+
+check_monitor_term_review_fixture() {
+  local file="$1" case_id mutation expected_status count=0
+  while IFS=$'\t' read -r case_id mutation expected_status; do
+    [ "$case_id" = case_id ] && continue
+    count=$((count + 1))
+    case "$mutation" in none|missing-review|malformed-review|wrong-run) : ;; *) return 1 ;; esac
+    case "$expected_status" in done|blocked) : ;; *) return 1 ;; esac
+    run_monitor_term_review_stub "$case_id" "$mutation" "$expected_status" || return 1
+  done < "$file"
+  [ "$count" -eq 4 ]
+}
+
+case_monitor_term_review_recovery() {
+  check_monitor_term_review_fixture "$FIXTURE_DIR/monitor-term-review-cases.tsv" ||
+    die "monitor TERM review recovery fixture rejected"
+  grep -Fq 'review candidate to `done` only when the candidate belongs to the expected' \
+    "$REPO_ROOT/skills/agent-delegate/references/contract.md" ||
+    die "English monitor TERM recovery contract is missing"
+  grep -Fq '未公開の review candidate を `done` として採用できるのは' \
+    "$REPO_ROOT/skills/agent-delegate/references/contract.ja.md" ||
+    die "Japanese monitor TERM recovery contract is missing"
+}
 
 check_owner_lock_signal_artifacts() {
   local report="$1" heartbeat="$2" dir="$3" label="$4" handoff="$5" expected_status="$6"
@@ -1910,9 +1992,9 @@ write_repeat_manifest() {
     --arg fixture "$fixture_hash" --arg harness "$harness_hash" --argjson beats "$CURRENT_HEARTBEATS" \
     --argjson terminals "$CURRENT_TERMINALS" '
     {iteration:$iteration,commit:$commit,hashes:{runner:$runner,fixture:$fixture,harness:$harness},
-     case_count:26,exit_code:0,heartbeat_updates:$beats,terminal_reports:$terminals,runtime_residue:false}
+     case_count:27,exit_code:0,heartbeat_updates:$beats,terminal_reports:$terminals,runtime_residue:false}
   ' > "$out"
-  jq -e '.case_count==26 and .exit_code==0 and .heartbeat_updates>=2 and .terminal_reports>=1 and .runtime_residue==false' "$out" >/dev/null
+  jq -e '.case_count==27 and .exit_code==0 and .heartbeat_updates>=2 and .terminal_reports>=1 and .runtime_residue==false' "$out" >/dev/null
 }
 
 if [ -n "$RUN_CASE" ]; then


### PR DESCRIPTION
## 概要

detachしたreviewが完了し、workerが同一runのcandidateを書いた直後にmonitorがTERMを受けると、正常な成果物が`blocked` / `env_error`へ置き換わる競合を修正します。

Fixes #110

## 原因

`monitor_finalize_abnormal()`は正式なterminal reportだけを保持し、未公開candidateの内容を検証せずに削除していました。
そのため、review成果物とcandidateが完成していても、正式reportの公開前にTERMを受けると完了結果を失っていました。

## 変更内容

- review構造検証を再利用可能な関数へ分離
- 同一runの完了済みreview candidateだけを`done`として公開するfail-closedな回収処理を追加
- run ID、mode、blocker、`touchedFiles`、成果物パス、review構造、同一runのfinal messageとの一致を検証
- 欠落、構造不正、別runの成果物は従来どおり`blocked` / `env_error`に維持
- 英語・日本語のdetach契約を更新
- TERM競合とnegative caseを実プロセスで再現するT-A28を追加

## 影響

挙動が変わるのは、detach reviewが完了済みcandidateを作成した後、正式report公開前にmonitorが異常終了した場合だけです。
delegate mode、review未完了、read-only違反、成果物不正の扱いは変わりません。

## 検証

- `monitor-term-review-recovery`: 3回連続PASS
- `clean-checkout-compatibility`: コミット済みHEADの隔離worktreeでPASS
- manifest 27件中26件: ケースごとの独立実行でPASS
- `spec-id-semantic-coverage`: git管理外の`.specs/agent-delegate-heartbeat/`が新worktreeにないため未実行
- Bash構文チェック: PASS
- skill品質チェック: PASS
- `git diff --check`: PASS
- Claude read-onlyレビュー再試行: `done`、`touchedFiles: []`
- ClaudeレビューGate: PASS（Critical 0、Improvement 2、Minor 2、`fix_before: implementation` 0）
