### PR TITLE
fix(spec-orchestrate): enforce phase completion state writes

### DIFF
--- a/skills/spec-orchestrate/references/pipeline-config.ja.md
+++ b/skills/spec-orchestrate/references/pipeline-config.ja.md
@@ -138,9 +138,9 @@ host_runtime="$(jq -r .host_runtime "$state")"
 
 アトミックに書く（その場編集しない — 一時ファイルに書いて mv）:
 ```bash
-jq '.phase = "inspect"
-    | .completed_phases += ["spec_generate"]
-    | .ts_updated = (now | todate)' "$state" > "$state.tmp" && mv "$state.tmp" "$state"
+jq --arg host "$host_runtime" \
+   '.host_runtime = $host | .ts_updated = (now | todate)' \
+   "$state" > "$state.tmp" && mv "$state.tmp" "$state"
 ```
 
 レビューラウンドを追記:
@@ -148,6 +148,43 @@ jq '.phase = "inspect"
 jq --argjson r '{"round":1,"critical":3,"improvement":2,"minor":1,"fix_required":2,"fingerprints":[],"class_keys":[],"gate":"FAIL"}' \
    '.rounds.spec_review += [$r]' "$state" > "$state.tmp" && mv "$state.tmp" "$state"
 ```
+
+<!-- phase-completion-state-write:start -->
+### フェーズ完了時の state 記帳チェックリスト
+
+フェーズを完了して遷移するたびに、このチェックリストを適用する。タスクを完了できるのは
+implement フェーズだけではない。
+
+1. state を書く前に、完了フェーズと次フェーズを確定する。
+2. `tasks.md` を読み直し、チェック済み正準タスク行だけから
+   `implement.tasks_done` を作る。`T[0-9]+[a-z]?(-[A-Za-z0-9]+)?` に一致する完全な
+   IDを保ち、重複を除き、`tasks.md` に存在しない、または未チェックのIDを残さない。
+3. 1回のアトミックな `jq` 更新で `.phase` を設定し、完了フェーズが未記録の場合だけ
+   `.completed_phases` へ追加し、`implement.tasks_done` を作成した配列で置き換える。
+   `implement` 以外のフェーズでタスクをチェックした場合も、同じ更新を行う。
+4. state を書いた後に run marker の時刻を更新する。
+5. 直ちに `references/scripts/pipeline-state-check.sh <spec-dir>` を実行する。
+   終了コードが0以外なら遷移を止め、乖離を修復し、検査がcleanになってから次フェーズを
+   dispatchする。
+
+チェック済み正準タスク行から `tasks_done_json` を作成した後の完了書き込み例
+（チェック済みタスクが0件なら、`tasks_done_json` は有効なJSON配列 `[]` とする）:
+
+```bash
+jq --arg finished "$finished_phase" --arg next "$next_phase" \
+   --argjson tasks_done "$tasks_done_json" '
+  .phase = $next
+  | .completed_phases = ((.completed_phases // []) |
+      if index($finished) then . else . + [$finished] end)
+  | .implement = ((.implement // {}) | .tasks_done = $tasks_done)
+  | .ts_updated = (now | todate)
+' "$state" > "$state.tmp" && mv "$state.tmp" "$state"
+jq '.ts = (now | todate)' .specs/.orchestrate-active.json \
+  > .specs/.orchestrate-active.json.tmp \
+  && mv .specs/.orchestrate-active.json.tmp .specs/.orchestrate-active.json
+bash references/scripts/pipeline-state-check.sh "$spec_dir"
+```
+<!-- phase-completion-state-write:end -->
 
 YAML パーサなしで `pipeline.yml` のロール値を読む（フラットな `roles:` ブロックの
 awk 流儀）:
@@ -209,8 +246,8 @@ hook はリポジトリごとに Claude Code の Stop hook として登録する
 偽装できない証拠と突き合わせる: 正準フェーズ順序と `completed_phases`（先のフェーズに
 居るのに前段が未記録 = state 更新なしでフェーズが走った。ただし `arbitrations` に
 `decision: "draft"` が記録された draft PR 着地は approval / implement / evaluate を
-免除する）、`tasks.md` のチェックボックスと `implement.tasks_done`（完全なタスクID文法
-`T[0-9]+[a-z]?(-[A-Za-z0-9]+)?` を切り詰めずに両方向で比較）、
+免除する）、`tasks.md` のチェックボックスと `implement.tasks_done`（state内の重複を
+拒否し、完全なタスクID文法 `T[0-9]+[a-z]?(-[A-Za-z0-9]+)?` を切り詰めずに両方向で比較）、
 運転記録ファイル（`retrospective.md`・`evaluate-*`）と記録上のフェーズ、そして
 `gh` があれば現在ブランチの PR 実在と `pr` 未到達の state。
 exit 0 = 整合、exit 1 = 乖離1件につき `DRIFT:` 行を1つ出力する。

--- a/skills/spec-orchestrate/references/pipeline-config.md
+++ b/skills/spec-orchestrate/references/pipeline-config.md
@@ -140,9 +140,9 @@ host_runtime="$(jq -r .host_runtime "$state")"
 
 Write atomically (never edit in place — write a temp file then move):
 ```bash
-jq '.phase = "inspect"
-    | .completed_phases += ["spec_generate"]
-    | .ts_updated = (now | todate)' "$state" > "$state.tmp" && mv "$state.tmp" "$state"
+jq --arg host "$host_runtime" \
+   '.host_runtime = $host | .ts_updated = (now | todate)' \
+   "$state" > "$state.tmp" && mv "$state.tmp" "$state"
 ```
 
 Append a review round:
@@ -150,6 +150,46 @@ Append a review round:
 jq --argjson r '{"round":1,"critical":3,"improvement":2,"minor":1,"fix_required":2,"fingerprints":[],"class_keys":[],"gate":"FAIL"}' \
    '.rounds.spec_review += [$r]' "$state" > "$state.tmp" && mv "$state.tmp" "$state"
 ```
+
+<!-- phase-completion-state-write:start -->
+### Phase completion state-write checklist
+
+Apply this checklist whenever a transition finishes a phase. Implementation is
+not the only phase that may complete a task.
+
+1. Determine the finished phase and the next phase before writing state.
+2. Re-read `tasks.md` and derive `implement.tasks_done` only from checked
+   canonical task rows. Preserve the complete id with
+   `T[0-9]+[a-z]?(-[A-Za-z0-9]+)?`, remove duplicates, and never retain an id
+   that is absent or unchecked in `tasks.md`.
+3. In one atomic `jq` update, set `.phase`, append the finished phase to
+   `.completed_phases` only when absent, and replace `implement.tasks_done` with
+   the derived array. Apply the same refresh when a phase other than
+   `implement` checks a task.
+4. Refresh the run-marker timestamp after the state write.
+5. Immediately run `references/scripts/pipeline-state-check.sh <spec-dir>`.
+   A non-zero exit blocks the transition: reconcile the drift and obtain a
+   clean check before dispatching the next phase.
+
+Example completion write after deriving `tasks_done_json` from the checked
+canonical rows (`tasks_done_json` must be the valid JSON array `[]` when no task
+is checked):
+
+```bash
+jq --arg finished "$finished_phase" --arg next "$next_phase" \
+   --argjson tasks_done "$tasks_done_json" '
+  .phase = $next
+  | .completed_phases = ((.completed_phases // []) |
+      if index($finished) then . else . + [$finished] end)
+  | .implement = ((.implement // {}) | .tasks_done = $tasks_done)
+  | .ts_updated = (now | todate)
+' "$state" > "$state.tmp" && mv "$state.tmp" "$state"
+jq '.ts = (now | todate)' .specs/.orchestrate-active.json \
+  > .specs/.orchestrate-active.json.tmp \
+  && mv .specs/.orchestrate-active.json.tmp .specs/.orchestrate-active.json
+bash references/scripts/pipeline-state-check.sh "$spec_dir"
+```
+<!-- phase-completion-state-write:end -->
 
 Reading a role value from `pipeline.yml` without a YAML parser (awk idiom for the
 flat `roles:` block):
@@ -211,8 +251,9 @@ file against evidence it cannot fake: the canonical phase order vs
 `completed_phases` (a later phase with unrecorded predecessors means a phase ran
 without its state update; a draft-PR landing recorded in `arbitrations` with
 `decision: "draft"` exempts the approval/implement/evaluate legs), `tasks.md`
-checkboxes vs `implement.tasks_done` (both directions, using the complete task-id
-grammar `T[0-9]+[a-z]?(-[A-Za-z0-9]+)?` without truncation), run-record files
+checkboxes vs `implement.tasks_done` (both directions, rejecting duplicate state
+entries, and using the complete task-id grammar
+`T[0-9]+[a-z]?(-[A-Za-z0-9]+)?` without truncation), run-record files
 (`retrospective.md`, `evaluate-*`) vs the recorded phase, and — when `gh` is
 available — an existing PR for the current branch vs a state that has not
 reached `pr`. Exit 0 is consistent; exit 1 prints one `DRIFT:` line per finding.

--- a/skills/spec-orchestrate/references/scripts/pipeline-state-check.sh
+++ b/skills/spec-orchestrate/references/scripts/pipeline-state-check.sh
@@ -93,19 +93,31 @@ fi
 
 # --- tasks.md checkboxes vs implement.tasks_done -----------------------------
 # Task ids are T-prefixed and may carry a lowercase or hyphenated suffix
-# (T000, T012b, T002-R, ...). Compare complete ids in both directions.
+# (T000, T012b, T002-R, ...). Compare complete ids in both directions and
+# reject duplicate state entries: tasks_done is a projection, not an event log.
 TASK_ID_PATTERN='T[0-9]+[a-z]?(-[A-Za-z0-9]+)?' # task-id-contract
 if [ -f "$SPEC_DIR/tasks.md" ] && jq -e '.implement.tasks_done' "$STATE" >/dev/null 2>&1; then
-  checked="$(
-    sed -nE \
-      "s/^[[:space:]]*[-*][[:space:]]+\[[xX]\][[:space:]]+($TASK_ID_PATTERN)([^A-Za-z0-9-]|$).*/\1/p" \
-      "$SPEC_DIR/tasks.md" | LC_ALL=C sort -u
-  )"
-  recorded="$(jq -r '.implement.tasks_done[]' "$STATE" | LC_ALL=C sort -u)"
-  only_checked="$(LC_ALL=C comm -23 <(printf '%s\n' $checked) <(printf '%s\n' $recorded) 2>/dev/null | tr '\n' ' ')"
-  only_recorded="$(LC_ALL=C comm -13 <(printf '%s\n' $checked) <(printf '%s\n' $recorded) 2>/dev/null | tr '\n' ' ')"
-  [ -n "${only_checked// /}" ] && report "tasks checked in tasks.md but missing from state.implement.tasks_done: $only_checked"
-  [ -n "${only_recorded// /}" ] && report "tasks in state.implement.tasks_done but unchecked in tasks.md: $only_recorded"
+  if ! jq -e --arg pattern "^${TASK_ID_PATTERN}$" '
+    .implement.tasks_done
+    | (type == "array") and all(.[];
+        if type == "string" then test($pattern) else false end)
+  ' "$STATE" >/dev/null 2>&1; then
+    report "implement.tasks_done must be an array of complete canonical task ids: $(jq -c '.implement.tasks_done' "$STATE")"
+  else
+    checked="$(
+      sed -nE \
+        "s/^[[:space:]]*[-*][[:space:]]+\[[xX]\][[:space:]]+($TASK_ID_PATTERN)([^A-Za-z0-9-]|$).*/\1/p" \
+        "$SPEC_DIR/tasks.md" | LC_ALL=C sort -u
+    )"
+    recorded_raw="$(jq -r '.implement.tasks_done[]' "$STATE")"
+    recorded_duplicates="$(printf '%s\n' "$recorded_raw" | sed '/^$/d' | LC_ALL=C sort | uniq -d | tr '\n' ' ')"
+    recorded="$(printf '%s\n' "$recorded_raw" | sed '/^$/d' | LC_ALL=C sort -u)"
+    only_checked="$(LC_ALL=C comm -23 <(printf '%s\n' $checked) <(printf '%s\n' $recorded) 2>/dev/null | tr '\n' ' ')"
+    only_recorded="$(LC_ALL=C comm -13 <(printf '%s\n' $checked) <(printf '%s\n' $recorded) 2>/dev/null | tr '\n' ' ')"
+    [ -n "${recorded_duplicates// /}" ] && report "duplicate ids in state.implement.tasks_done: $recorded_duplicates"
+    [ -n "${only_checked// /}" ] && report "tasks checked in tasks.md but missing from state.implement.tasks_done: $only_checked"
+    [ -n "${only_recorded// /}" ] && report "tasks in state.implement.tasks_done but unchecked in tasks.md: $only_recorded"
+  fi
 fi
 
 # --- run-record files vs phase progression -----------------------------------

--- a/skills/spec-orchestrate/references/scripts/tests/fixtures/phase-completion-state-write.tsv
+++ b/skills/spec-orchestrate/references/scripts/tests/fixtures/phase-completion-state-write.tsv
@@ -1,0 +1,10 @@
+contract_id	en_token	ja_token
+phase_pair	Determine the finished phase and the next phase	完了フェーズと次フェーズを確定
+task_source	Re-read `tasks.md`	`tasks.md` を読み直し
+task_grammar	T[0-9]+[a-z]?(-[A-Za-z0-9]+)?	T[0-9]+[a-z]?(-[A-Za-z0-9]+)?
+atomic_update	In one atomic `jq` update	1回のアトミックな `jq` 更新
+idempotent_phase	only when absent	完了フェーズが未記録の場合だけ
+non_implement	phase other than	`implement` 以外のフェーズ
+marker_refresh	Refresh the run-marker timestamp	run marker の時刻を更新
+checker_command	references/scripts/pipeline-state-check.sh	references/scripts/pipeline-state-check.sh
+integrity_gate	A non-zero exit blocks the transition	終了コードが0以外なら遷移を止め

--- a/skills/spec-orchestrate/references/scripts/tests/fixtures/task-id-cases.tsv
+++ b/skills/spec-orchestrate/references/scripts/tests/fixtures/task-id-cases.tsv
@@ -5,4 +5,6 @@ mixed-identifiers	T001,T002-R,T012b	T001,T002-R,T012b	pass	STATE OK	fixture task
 description-reference	T001	T001	pass	STATE OK	depends on T002-T003
 truncated-state	T002-R	T002	fail	T002-R	fixture task
 unknown-recorded	T002-R	T002-R,T999-X	fail	T999-X	fixture task
+duplicate-recorded	T002-R	T002-R,T002-R	fail	duplicate ids in state.implement.tasks_done	fixture task
+empty-recorded-id	-	<empty-id>	fail	implement.tasks_done must be an array of complete canonical task ids	fixture task
 no-checked-tasks	-	T999-X	fail	T999-X	fixture task

--- a/skills/spec-orchestrate/references/scripts/tests/run_tests.sh
+++ b/skills/spec-orchestrate/references/scripts/tests/run_tests.sh
@@ -9,6 +9,7 @@ SKILLS_DIR="$(cd "$ORCHESTRATE_DIR/.." && pwd)"
 FIXTURE="$TEST_DIR/fixtures/dispatch-matrix.tsv"
 REVIEW_FIXTURE="$TEST_DIR/fixtures/review-fallback.tsv"
 SPEC_REVIEW_RECOVERY_FIXTURE="$TEST_DIR/fixtures/spec-review-env-error-contract.tsv"
+STATE_WRITE_FIXTURE="$TEST_DIR/fixtures/phase-completion-state-write.tsv"
 TASK_ID_FIXTURE="$TEST_DIR/fixtures/task-id-cases.tsv"
 ROLE_DISPATCH="$REFERENCE_DIR/role-dispatch.md"
 ROLE_DISPATCH_JA="$REFERENCE_DIR/role-dispatch.ja.md"
@@ -138,6 +139,56 @@ assert_spec_review_recovery_mutations_rejected() {
   done < "$SPEC_REVIEW_RECOVERY_FIXTURE"
 }
 
+extract_phase_completion_state_write_contract() {
+  awk '
+    /<!-- phase-completion-state-write:start -->/ { inside=1; next }
+    /<!-- phase-completion-state-write:end -->/ { inside=0 }
+    inside { print }
+  ' "$1"
+}
+
+validate_phase_completion_state_write_contract() {
+  local file="$1" language="$2" field contract_id en_token ja_token token section
+
+  [ "$(grep -c '<!-- phase-completion-state-write:start -->' "$file")" -eq 1 ] || return 1
+  [ "$(grep -c '<!-- phase-completion-state-write:end -->' "$file")" -eq 1 ] || return 1
+  section="$(extract_phase_completion_state_write_contract "$file")"
+  [ -n "$section" ] || return 1
+
+  case "$language" in
+    en) field=2 ;;
+    ja) field=3 ;;
+    *) return 1 ;;
+  esac
+
+  while IFS=$'\t' read -r contract_id en_token ja_token; do
+    [ "$contract_id" = contract_id ] && continue
+    if [ "$field" -eq 2 ]; then token="$en_token"; else token="$ja_token"; fi
+    printf '%s\n' "$section" | grep -Fq -- "$token" || return 1
+  done < "$STATE_WRITE_FIXTURE"
+}
+
+assert_phase_completion_state_write_mutations_rejected() {
+  local file="$1" language="$2" field contract_id en_token ja_token token mutant
+
+  case "$language" in
+    en) field=2 ;;
+    ja) field=3 ;;
+    *) return 1 ;;
+  esac
+
+  while IFS=$'\t' read -r contract_id en_token ja_token; do
+    [ "$contract_id" = contract_id ] && continue
+    if [ "$field" -eq 2 ]; then token="$en_token"; else token="$ja_token"; fi
+    mutant="$tmp/phase-completion-state-write-$language-$contract_id.md"
+    awk -v token="$token" 'index($0, token) == 0 { print }' "$file" > "$mutant"
+    if validate_phase_completion_state_write_contract "$mutant" "$language"; then
+      printf 'SURVIVED_MUTATION\t%s\t%s\n' "$language" "$contract_id" >&2
+      return 1
+    fi
+  done < "$STATE_WRITE_FIXTURE"
+}
+
 write_task_id_state() {
   local spec_dir="$1" checked_ids="$2" recorded_ids="$3" task_text="$4" tasks_done
 
@@ -147,8 +198,12 @@ write_task_id_state() {
       printf -- '- [x] %s: %s\n' "$task_id" "$task_text"
     fi
   done > "$spec_dir/tasks.md"
-  tasks_done="$(jq -Rn --arg ids "$recorded_ids" \
-    '$ids | if length == 0 or . == "-" then [] else split(",") end')"
+  if [ "$recorded_ids" = "<empty-id>" ]; then
+    tasks_done='[""]'
+  else
+    tasks_done="$(jq -Rn --arg ids "$recorded_ids" \
+      '$ids | if length == 0 or . == "-" then [] else split(",") end')"
+  fi
   jq -n --argjson tasks_done "$tasks_done" '{
     feature: "task-id-fixture",
     mode: "auto",
@@ -283,6 +338,16 @@ assert_spec_review_recovery_mutations_rejected "$SPEC_REVIEW_PHASE_JA" ja ||
   fail "Japanese spec_review recovery validator accepted a contract mutation"
 printf 'PASS\tcontract\tspec_review env_error artifact recovery\n'
 
+validate_phase_completion_state_write_contract "$PIPELINE_CONFIG" en ||
+  fail "English phase completion state-write contract is incomplete"
+validate_phase_completion_state_write_contract "$PIPELINE_CONFIG_JA" ja ||
+  fail "Japanese phase completion state-write contract is incomplete"
+assert_phase_completion_state_write_mutations_rejected "$PIPELINE_CONFIG" en ||
+  fail "English phase completion state-write validator accepted a contract mutation"
+assert_phase_completion_state_write_mutations_rejected "$PIPELINE_CONFIG_JA" ja ||
+  fail "Japanese phase completion state-write validator accepted a contract mutation"
+printf 'PASS\tcontract\tphase completion state write\n'
+
 grep -Fq "TASK_ID_PATTERN='$TASK_ID_GRAMMAR'" "$STATE_CHECK" ||
   fail "state checker task id grammar differs from the tracked contract"
 for task_id_contract in \
@@ -293,7 +358,8 @@ done
 printf 'PASS\tcontract\ttask id grammar in checker and bilingual docs\n'
 
 for fixture_file in \
-  "$FIXTURE" "$REVIEW_FIXTURE" "$SPEC_REVIEW_RECOVERY_FIXTURE" "$TASK_ID_FIXTURE"; do
+  "$FIXTURE" "$REVIEW_FIXTURE" "$SPEC_REVIEW_RECOVERY_FIXTURE" \
+  "$STATE_WRITE_FIXTURE" "$TASK_ID_FIXTURE"; do
   last_byte="$(tail -c 1 "$fixture_file" | od -An -t u1 | tr -d '[:space:]')"
   [ "$last_byte" = 10 ] || fail "$fixture_file must end with a newline"
 done


### PR DESCRIPTION
## 概要

- 日英の`pipeline-config`へ、フェーズ完了時のstate記帳チェックリストを追加しました。
- `.phase`、`completed_phases`、`implement.tasks_done`を1回のatomicな`jq`更新で同期します。
- `tasks_done`の重複・空ID・不正IDを`pipeline-state-check.sh`でdriftとして検出します。
- 契約fixtureとmutation testを追加し、日英の各受入条件を固定しました。

## 背景と原因

実運用プロジェクトのdogfoodでは、フェーズ遷移と`completed_phases`の更新が分離し、`tasks.md`を正本にせず`tasks_done`を追記したため、完了フェーズの欠落とタスクIDの重複が発生しました。

従来の文書には個別の更新規則はありましたが、フェーズ完了時に必ず一括で確認する手順と、`implement`以外で完了したタスクを同じstate書き込みへ反映する規則がまとまっていませんでした。

## 変更内容

- 完了フェーズと次フェーズをstate書き込み前に確定
- チェック済み正準タスク行から完全なIDを再抽出
- ハイフン付きIDを保持し、未知・未チェック・重複IDを排除
- フェーズ遷移、完了フェーズ、タスク投影を同じatomic更新で記帳
- run marker更新後に整合性検査を実行し、drift時は次フェーズへ進まない
- 日英契約の条項削除を検出するmutation testを追加

## 検証

- `bash -n skills/spec-orchestrate/references/scripts/pipeline-state-check.sh`
- `bash -n skills/spec-orchestrate/references/scripts/tests/run_tests.sh`
- `bash skills/spec-orchestrate/references/scripts/tests/run_tests.sh`
- `git diff --check`
- プレサブミット確認：frontmatter名、SKILL.md 500行以下、禁止MCP名なし
- Claude read-onlyレビュー：Critical 0 / Improvement 0 / Minor 3 / Gate PASS

`shellcheck`はローカル未導入のため未実行です。

## 影響

state記帳漏れや`tasks_done`のイベントログ化を、フェーズ遷移直後に検出して停止できるようになります。
既存の正準タスクID文法と、古いstateで`review_fallbacks`が省略可能な互換性は維持しています。

Closes #133
