### PR TITLE
test: 実行記録ignoreの過剰一致をgitで検出する negative test を追加する (closes #154)

### DIFF
--- a/skills/agent-delegate/references/scripts/tests/run_tests.sh
+++ b/skills/agent-delegate/references/scripts/tests/run_tests.sh
@@ -1565,6 +1565,135 @@ check_runtime_record_and_skills_repo_mutations() {
   rm -rf "$dir"
 }
 
+# Extract the fenced block intake tells the agent to write verbatim into .specs/.gitignore.
+# The document-text checks above verify the block mentions the required formats; this extraction
+# lets the checks below verify what git actually does with the block.
+extract_intake_gitignore_block() {
+  local file="$1"
+  awk '
+    /^```/ {
+      if (in_fence) {
+        if (candidate && marker && $0 ~ /^```[[:space:]]*$/) {printf "%s", buffer; emitted=1; exit}
+        in_fence=candidate=marker=0; buffer=""
+      } else {
+        in_fence=1
+        candidate=($0 ~ /^```(gitignore)?[[:space:]]*$/)
+        marker=0; buffer=""
+      }
+      next
+    }
+    in_fence && candidate {
+      if ($0 ~ /^# spec-orchestrate run records/) marker=1
+      buffer = buffer $0 "\n"
+    }
+    END {exit !emitted}
+  ' "$file"
+}
+
+# Spec artifacts whose commit status pipeline-config.md leaves to the project.
+# The run-record .gitignore must never hide them.
+gitignore_projection_spec_artifacts() {
+  printf '%s\n' \
+    '.specs/sample-feature/requirement.md' \
+    '.specs/sample-feature/design.md' \
+    '.specs/sample-feature/tasks.md' \
+    '.specs/sample-feature/test.md'
+}
+
+# One representative filename per pattern the block lists. Every one must stay ignored.
+gitignore_projection_run_records() {
+  printf '%s\n' \
+    '.specs/pipeline-metrics.jsonl' \
+    '.specs/.orchestrate-active.json' \
+    '.specs/sample-feature/pipeline-state.json' \
+    '.specs/sample-feature/inspection-report.md' \
+    '.specs/sample-feature/.inspection_result.json' \
+    '.specs/sample-feature/review-1.md' \
+    '.specs/sample-feature/evaluate-1.md' \
+    '.specs/sample-feature/evidence/screenshot.png' \
+    '.specs/sample-feature/retrospective.md' \
+    '.specs/sample-feature/plan-report.json' \
+    '.specs/sample-feature/plan-heartbeat.json' \
+    '.specs/sample-feature/plan-owner.json' \
+    '.specs/sample-feature/plan-owner.lock/held' \
+    '.specs/sample-feature/plan-report.candidate.1.json' \
+    '.specs/sample-feature/plan-last.txt' \
+    '.specs/sample-feature/plan-last.1.txt' \
+    '.specs/sample-feature/plan-stdout.json' \
+    '.specs/sample-feature/plan-stdout.jsonl' \
+    '.specs/sample-feature/plan-stdout.1.json' \
+    '.specs/sample-feature/plan-stdout.1.jsonl' \
+    '.specs/sample-feature/plan-stderr.log' \
+    '.specs/sample-feature/plan.pid'
+}
+
+# Project the given block into a throwaway repository as .specs/.gitignore and let git itself
+# decide: spec artifacts must show up in git status, run records must not.
+# Global and system gitignore files are disabled so the verdict does not depend on the machine.
+check_gitignore_projection() {
+  local block="$1" dir status relative
+  dir="$(new_work_dir)"
+  if ! GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+      git -C "$dir" init --quiet >/dev/null 2>&1; then
+    rm -rf "$dir"
+    return 1
+  fi
+  mkdir -p "$dir/.specs/sample-feature"
+  printf '%s\n' "$block" > "$dir/.specs/.gitignore"
+  while IFS= read -r relative; do
+    mkdir -p "$dir/$(dirname "$relative")"
+    printf 'fixture\n' > "$dir/$relative"
+  done < <(gitignore_projection_spec_artifacts; gitignore_projection_run_records)
+
+  status="$(GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+    git -C "$dir" status --porcelain --untracked-files=all)" || {
+    rm -rf "$dir"
+    return 1
+  }
+
+  while IFS= read -r relative; do
+    if ! printf '%s\n' "$status" | grep -Fxq "?? $relative"; then
+      rm -rf "$dir"
+      return 1
+    fi
+  done < <(gitignore_projection_spec_artifacts)
+
+  while IFS= read -r relative; do
+    if printf '%s\n' "$status" | grep -Fq "$relative"; then
+      rm -rf "$dir"
+      return 1
+    fi
+  done < <(gitignore_projection_run_records)
+
+  rm -rf "$dir"
+}
+
+check_gitignore_projection_mutations() {
+  local block block_ja mutated
+  block="$(extract_intake_gitignore_block \
+    "$REPO_ROOT/skills/spec-orchestrate/references/phases/intake.md")" || return 1
+  block_ja="$(extract_intake_gitignore_block \
+    "$REPO_ROOT/skills/spec-orchestrate/references/phases/intake.ja.md")" || return 1
+  # Both languages must dictate the same file; editing one alone changes what a project ignores
+  # depending on which document the agent read.
+  [ "$block" = "$block_ja" ] || return 1
+  check_gitignore_projection "$block" || return 1
+
+  # Over-matching 1: widening a run-record pattern also hides the spec artifacts.
+  mutated="$(printf '%s\n' "$block" | awk '{print ($0=="*/review-*.md") ? "*/*.md" : $0}')"
+  [ "$mutated" != "$block" ] || return 1
+  if check_gitignore_projection "$mutated"; then return 1; fi
+
+  # Over-matching 2: adding a pattern that reaches a spec artifact hides test.md.
+  mutated="$(printf '%s\n%s\n' "$block" '*/test*.md')"
+  if check_gitignore_projection "$mutated"; then return 1; fi
+
+  # Under-matching: dropping a run-record pattern lets that record reach git status.
+  mutated="$(printf '%s\n' "$block" | grep -vFx '*/*-stdout.json')"
+  [ "$mutated" != "$block" ] || return 1
+  if check_gitignore_projection "$mutated"; then return 1; fi
+}
+
 check_document_contracts() {
   local fixture="$1" test_id="$2"
   check_contract_fixture "$fixture" &&
@@ -1614,6 +1743,8 @@ case_bilingual_contract_and_runtime_records() {
     die 'bilingual document contract fixture or section contract rejected'
   check_runtime_record_and_skills_repo_mutations ||
     die 'runtime record or skills_repo scoped positive and negative checks failed'
+  check_gitignore_projection_mutations ||
+    die 'gitignore projection hid a spec artifact or exposed a run record'
 }
 
 check_compatibility_fixture() {


### PR DESCRIPTION
## 概要

実行記録の `.gitignore` について、これまでの契約テストは「必須4形式が文書に書かれているか」しか見ていなかった。パターンが仕様成果物まで隠しても、文書に4形式が残っていれば通ってしまう。intake が書かせるブロックを実際の `.gitignore` として展開し、git 自身に判定させる検査を T-A13 へ追加する。

- `extract_intake_gitignore_block` — `intake.md` / `intake.ja.md` から `.gitignore` ブロックの中身を取り出す。文書の文言ではなく、実際に `.specs/.gitignore` へ書かれる内容を検査対象にする。
- `check_gitignore_projection` — 取り出したブロックを使い捨ての git リポジトリへ `.specs/.gitignore` として展開し、仕様成果物4件が `git status` へ現れること、実行記録22件が現れないことを検査する。利用者の global / system gitignore に判定が左右されないよう、両方を無効にして git を実行する。
- `check_gitignore_projection_mutations` — 英日ブロックの一致を確認したうえで、過剰一致2種と取りこぼし1種の変異を拒否する。
- 新しい case は登録していない。T-A13 が intake 英日版と pipeline-config 英日版の実行記録契約を担当しており、同じ契約を別の方法で検査するものだから。case 数は 27 のまま。

## この検査が捕まえるもの

実際の `intake.md` と `intake.ja.md` を変異させ、追加した検査だけが落ちることを確認した。いずれの変異も必須4形式を消していないため、既存の文言検査は通過する。

| 変異 | 変異前 | 結果 |
|---|---|---|
| 実行記録のパターンを広げる | `*/review-*.md` → `*/*.md` | TEST_FAIL |
| 仕様成果物に届くパターンを足す | `*/test*.md` を追加 | TEST_FAIL |
| 日本語版だけ1行足す | `intake.ja.md` のみ変更 | TEST_FAIL |
| 変異なし | — | PASS |

## テスト計画

- [x] `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --case bilingual-contract-and-runtime-records`
- [x] `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --all`
- [x] `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --all --repeat 3`
- [x] `bash scripts/check-skill-line-budget.sh`
- [x] `bash scripts/tests/check-skill-reference-split-contract.sh`
- [x] 上表の変異検査（追加した検査が規制として働くことの確認）

`--all` の実行には注意点がある。`spec-id-semantic-coverage` は `.specs/agent-delegate-heartbeat/` の仕様4ファイルが repository root にあることを要求するが、このディレクトリは `.gitignore` の `.specs/` で除外されており git 管理下にない。そのため新しい worktree では `TEST_FAIL missing spec: requirement.md` で落ちる。今回は main checkout から同ディレクトリを複製して前提を揃えたうえで `--all` と `--repeat 3` を通した。本 PR の変更とは無関係の既存の環境依存だが、別途扱いを決めたほうがよい。

## 関連

- closes #154
- Downstream: value-market/growth-code#140 — Growth Code 側の同等検査は value-market/growth-code#144 で導入済み。本 PR は #140 が上流へ残していた分を扱う。