### PR TITLE
fix: SKILL.md品質検査のコードフェンス誤検出を解消

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,9 @@ Before submitting, verify:
 3. No hardcoded MCP tool names (e.g., `mcp__serena__`, `Context7`)
 4. SKILL.md is under 500 lines
 5. `bash scripts/check-skill-line-budget.sh` passes for the whole repository
-6. For reference-split changes, `bash scripts/tests/check-skill-reference-split-contract.sh` passes
+6. `bash skills/agent-delegate/references/scripts/tests/check_skill_quality.sh skills/*/SKILL.md` passes for the whole repository
+7. Changes to the quality checker pass `bash skills/agent-delegate/references/scripts/tests/check_skill_quality_contract.sh`
+8. For reference-split changes, `bash scripts/tests/check-skill-reference-split-contract.sh` passes
 
 ## コーディングルール
 

--- a/docs/coding-rules.md
+++ b/docs/coding-rules.md
@@ -32,11 +32,12 @@
 - 出典: AGENTS.md (L26-48)
 
 ### [MUST] SKILL.md 本文は英語で記述
-- セクションヘッダー、チェック/ステップ説明、検出パターン、コードコメントすべて英語
+- SKILL.md 文書のセクションヘッダー、チェック/ステップ説明、検出パターン、コードコメントは英語
+- fenced code example 内の ATX 形式見出しは例示内容として扱い、文書見出しの言語規則から除外する
 - 出典: AGENTS.md (L55), docs/skill-style-guide.md (L7-14)
 
 ### [MUST] セクションヘッダーは英語
-- すべてのヘッダーを英語で記述する（`## Execution Flow`, not `## 実行フロー`）
+- SKILL.md の fenced code example 外にあるすべての ATX 形式文書ヘッダーを英語で記述する（`## Execution Flow`, not `## 実行フロー`）
 - 出典: docs/skill-style-guide.md (L90-101)
 
 ### [MUST] Language Rules セクション必須

--- a/docs/review_rules.md
+++ b/docs/review_rules.md
@@ -20,7 +20,7 @@
 - `[MUST]` SKILL.md 本文は英語で記述すること
 - `[MUST]` `## Language Rules` セクションが存在すること
 - `[MUST]` AskUserQuestion テキストはバイリンガル（`"English" / "日本語"`）
-- `[MUST]` セクションヘッダーは英語であること
+- `[MUST]` SKILL.md の fenced code example 外にある ATX 形式文書セクションヘッダーは英語であること（フェンス内の例示見出しは除外）
 - `[MUST]` タイトル形式: `# skill-name — Short Description`
 - `[SHOULD]` セクション順序: フロントマター → タイトル → 紹介 → Language Rules → コア → Error Handling → Usage Examples
 
@@ -35,6 +35,7 @@
 ## 5. テスト
 
 - `[MUST]` プレサブミットチェック: フロントマター name 一致、参照ファイル存在、MCP ツール名なし、500 行未満
+- `[MUST]` `bash skills/agent-delegate/references/scripts/tests/check_skill_quality.sh skills/*/SKILL.md`でリポジトリ内の全`SKILL.md`を検査する
 - `[MUST]` `bash scripts/check-skill-line-budget.sh`でリポジトリ内の全`SKILL.md`を検査する
 - `[MUST]` reference分割を変更した場合は`bash scripts/tests/check-skill-reference-split-contract.sh`を実行する
 - `[SHOULD]` テスト名は振る舞いを記述する

--- a/docs/skill-style-guide.md
+++ b/docs/skill-style-guide.md
@@ -89,7 +89,7 @@ Use the skill's kebab-case name, an em dash, and a concise English description.
 
 ### Section Headers
 
-All headers must be in English. Common headers:
+All ATX-style document headers in SKILL.md must be in English. ATX-style headings shown inside fenced code examples are illustrative content and are exempt from this rule. Common headers:
 
 | Header | Usage |
 |--------|-------|
@@ -107,11 +107,13 @@ Before submitting a new or updated SKILL.md, verify:
 - [ ] Frontmatter `name` matches directory name
 - [ ] Body is written in English
 - [ ] `## Language Rules` section is present
-- [ ] All section headers are in English
+- [ ] All document section headers outside fenced code examples are in English
 - [ ] AskUserQuestion content is bilingual (`"English" / "日本語"`)
 - [ ] Reference files follow `*.md` / `*.ja.md` pattern
 - [ ] Total line count is under 500
 - [ ] `bash scripts/check-skill-line-budget.sh` passes from the repository root
+- [ ] `bash skills/agent-delegate/references/scripts/tests/check_skill_quality.sh skills/*/SKILL.md` passes from the repository root
+- [ ] Changes to the quality checker pass `bash skills/agent-delegate/references/scripts/tests/check_skill_quality_contract.sh`
 - [ ] Skills selected for size reduction are at most 450 lines and `bash scripts/tests/check-skill-reference-split-contract.sh` passes
 - [ ] No hardcoded MCP tool names (e.g., `mcp__serena__`, `Context7`)
 - [ ] All referenced files exist

--- a/skills/agent-delegate/references/scripts/tests/check_skill_quality.sh
+++ b/skills/agent-delegate/references/scripts/tests/check_skill_quality.sh
@@ -31,6 +31,60 @@ description_text() {
   ' "$1"
 }
 
+markdown_headings() {
+  awk '
+    function marker_length(line, marker, count) {
+      count=0
+      while (substr(line, count + 1, 1) == marker) count++
+      return count
+    }
+    function opening_fence_indent_ok(line, i, char, spaces) {
+      spaces=0
+      for (i=1; i<=length(line); i++) {
+        char=substr(line, i, 1)
+        if (char == " ") {
+          spaces++
+          if (spaces > 3) return 0
+        } else if (char == "\t") {
+          return 0
+        } else {
+          break
+        }
+      }
+      return 1
+    }
+    NR == 1 && $0 == "---" { in_frontmatter=1; next }
+    in_frontmatter && $0 == "---" { in_frontmatter=0; next }
+    in_frontmatter { next }
+    {
+      opening_indent_ok=opening_fence_indent_ok($0)
+      trimmed=$0
+      sub(/^[[:space:]]*/, "", trimmed)
+      marker=substr(trimmed, 1, 1)
+      run_length=0
+      if (marker == "`" || marker == "~") run_length=marker_length(trimmed, marker)
+      if (in_fence) {
+        rest=substr(trimmed, run_length + 1)
+        if (opening_indent_ok && marker == fence_marker && run_length >= fence_length && rest ~ /^[[:space:]]*$/) {
+          in_fence=0
+        }
+        next
+      }
+      if (opening_indent_ok && (marker == "`" || marker == "~") && run_length >= 3) {
+        in_fence=1
+        fence_marker=marker
+        fence_length=run_length
+        next
+      }
+      if (opening_indent_ok && trimmed ~ /^#{1,6}[[:space:]]/) print trimmed
+    }
+    END {
+      if (in_frontmatter) exit 11
+      if (in_fence) exit 10
+    }
+  ' "$1"
+}
+
 check_reference_paths() {
   local file="$1" skill_dir reference english japanese
   skill_dir="$(cd "$(dirname "$file")" && pwd)"
@@ -50,7 +104,7 @@ check_reference_paths() {
 }
 
 check_skill() {
-  local file="$1" dir_name name license description description_length title non_ascii_heading
+  local file="$1" dir_name name license description description_length headings heading_status title non_ascii_heading
   [ -f "$file" ] || { fail "$file" "file does not exist"; return; }
   [ "$(sed -n '1p' "$file")" = '---' ] || fail "$file" "missing YAML frontmatter"
 
@@ -66,12 +120,21 @@ check_skill() {
   printf '%s\n' "$description" | grep -q 'English triggers:' || fail "$file" "missing English triggers"
   printf '%s\n' "$description" | grep -q '日本語トリガー:' || fail "$file" "missing Japanese triggers"
 
-  title="$(awk '/^---$/{count++; next} count==2 && /^# /{print; exit}' "$file")"
-  printf '%s\n' "$title" | grep -Eq "^# ${name} — [[:alnum:]]" || fail "$file" "title must use '# ${name} — Short Description'"
-  grep -q '^## Language Rules$' "$file" || fail "$file" "missing Language Rules"
-  grep -q '^## [A-Za-z0-9]' "$file" || fail "$file" "body must use English headings"
-  non_ascii_heading="$(grep -E '^#{2,6} ' "$file" | grep '[ぁ-んァ-ヶ一-龠]' || true)"
-  [ -z "$non_ascii_heading" ] || fail "$file" "headings must be English"
+  headings="$(markdown_headings "$file")"
+  heading_status=$?
+  case "$heading_status" in
+    0)
+      title="$(printf '%s\n' "$headings" | grep -m1 '^# ' || true)"
+      printf '%s\n' "$title" | grep -Eq "^# ${name} — [[:alnum:]]" || fail "$file" "title must use '# ${name} — Short Description'"
+      printf '%s\n' "$headings" | grep -q '^## Language Rules$' || fail "$file" "missing Language Rules"
+      printf '%s\n' "$headings" | grep -q '^## [A-Za-z0-9]' || fail "$file" "body must use English headings"
+      non_ascii_heading="$(printf '%s\n' "$headings" | grep '[ぁ-んァ-ヶ一-龠]' || true)"
+      [ -z "$non_ascii_heading" ] || fail "$file" "headings must be English"
+      ;;
+    10) fail "$file" "unclosed fenced code block" ;;
+    11) fail "$file" "unclosed YAML frontmatter" ;;
+    *) fail "$file" "could not parse Markdown headings" ;;
+  esac
 
   if grep -q 'AskUserQuestion' "$file"; then
     grep -qE 'AskUserQuestion|request_user_input' "$file" || fail "$file" "interactive choices must use AskUserQuestion"

--- a/skills/agent-delegate/references/scripts/tests/check_skill_quality_contract.sh
+++ b/skills/agent-delegate/references/scripts/tests/check_skill_quality_contract.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QUALITY="$TEST_DIR/check_skill_quality.sh"
+REPO_ROOT="$(git -C "$TEST_DIR" rev-parse --show-toplevel)"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/skill-quality-contract.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT TERM INT HUP
+
+new_fixture() {
+  local case_name="$1" skill_dir
+  skill_dir="$WORK_DIR/$case_name/fixture-skill"
+  mkdir -p "$skill_dir"
+  printf '%s\n' \
+    '---' \
+    'name: fixture-skill' \
+    'description: |' \
+    '  English triggers: "validate fixture".' \
+    '  日本語トリガー: 「fixtureを検査」' \
+    'license: MIT' \
+    '## 日本語のYAMLコメント' \
+    '---' \
+    '# fixture-skill — Validate Markdown Headings' \
+    '' \
+    '## Language Rules' \
+    '' \
+    'Respond in the user language.' \
+    '' \
+    '## Execution Flow' \
+    '' \
+    'Validate the fixture.' > "$skill_dir/SKILL.md"
+  printf '%s\n' "$skill_dir/SKILL.md"
+}
+
+expect_pass() {
+  local label="$1" file="$2"
+  bash "$QUALITY" "$file" >/dev/null || {
+    printf 'CONTRACT_FAIL\t%s\texpected pass\n' "$label" >&2
+    return 1
+  }
+}
+
+expect_failure() {
+  local label="$1" file="$2" expected="$3" output rc
+  set +e
+  output="$(bash "$QUALITY" "$file" 2>&1)"
+  rc=$?
+  set -e
+  if [ "$rc" -ne 1 ] || ! printf '%s\n' "$output" | grep -q "$expected" ||
+      ! printf '%s\n' "$output" | grep -Fqx $'SKILL_QUALITY_SUMMARY\tFAIL\t1'; then
+    printf 'CONTRACT_FAIL\t%s\texpected failure containing: %s\n%s\n' "$label" "$expected" "$output" >&2
+    return 1
+  fi
+}
+
+bash "$QUALITY" \
+  "$REPO_ROOT/skills/cmux-second-opinion/SKILL.md" \
+  "$REPO_ROOT/skills/mcp-convert/SKILL.md" \
+  "$REPO_ROOT/skills/skill-suggest/SKILL.md" >/dev/null || {
+    printf 'CONTRACT_FAIL\tactual-skills\texpected pass\n' >&2
+    exit 1
+  }
+
+fenced_fixture="$(new_fixture fenced-headings)"
+cat >> "$fenced_fixture" <<'EOF'
+
+````markdown
+## 日本語の出力例
+`````
+
+   ~~~text
+### 日本語の出力例
+   ~~~~
+
+```text
+``` trailing text is code, not a closing fence
+## 日本語の出力例
+```
+EOF
+expect_pass fenced-headings "$fenced_fixture"
+
+real_heading_fixture="$(new_fixture real-heading)"
+printf '\n## 日本語の実見出し\n' >> "$real_heading_fixture"
+expect_failure real-heading "$real_heading_fixture" 'headings must be English'
+
+indented_heading_fixture="$(new_fixture indented-heading)"
+printf '\n   ## 日本語の実見出し\n' >> "$indented_heading_fixture"
+expect_failure indented-heading "$indented_heading_fixture" 'headings must be English'
+
+indented_code_fixture="$(new_fixture four-space-heading)"
+printf '\n    ## 日本語のコード例\n' >> "$indented_code_fixture"
+expect_pass four-space-heading "$indented_code_fixture"
+
+fake_opening_fixture="$(new_fixture four-space-opening)"
+cat >> "$fake_opening_fixture" <<'EOF'
+
+    ```markdown
+## 日本語の実見出し
+    ```
+EOF
+expect_failure four-space-opening "$fake_opening_fixture" 'headings must be English'
+
+tilde_closer_fixture="$(new_fixture tilde-closer)"
+cat >> "$tilde_closer_fixture" <<'EOF'
+
+~~~text
+## 日本語の出力例
+~~~
+## 日本語の実見出し
+EOF
+expect_failure tilde-closer "$tilde_closer_fixture" 'headings must be English'
+
+long_closer_fixture="$(new_fixture longer-backtick-closer)"
+cat >> "$long_closer_fixture" <<'EOF'
+
+````text
+## 日本語の出力例
+`````
+## 日本語の実見出し
+EOF
+expect_failure longer-backtick-closer "$long_closer_fixture" 'headings must be English'
+
+indented_closer_fixture="$(new_fixture indented-closer)"
+cat >> "$indented_closer_fixture" <<'EOF'
+
+```text
+## 日本語の出力例
+   ```
+## 日本語の実見出し
+EOF
+expect_failure indented-closer "$indented_closer_fixture" 'headings must be English'
+
+marker_match_fixture="$(new_fixture marker-match)"
+cat >> "$marker_match_fixture" <<'EOF'
+
+```text
+~~~
+## 日本語の出力例
+```
+EOF
+expect_pass marker-match "$marker_match_fixture"
+
+reverse_marker_fixture="$(new_fixture reverse-marker-match)"
+cat >> "$reverse_marker_fixture" <<'EOF'
+
+~~~text
+```
+## 日本語の出力例
+~~~
+EOF
+expect_pass reverse-marker-match "$reverse_marker_fixture"
+
+tab_indented_fixture="$(new_fixture tab-indented-code)"
+printf '\n\t```markdown\n## 日本語の実見出し\n\t```\n' >> "$tab_indented_fixture"
+expect_failure tab-indented-code "$tab_indented_fixture" 'headings must be English'
+
+fenced_title_fixture="$(new_fixture fenced-title)"
+awk '$0 == "# fixture-skill — Validate Markdown Headings" { print "Title"; next } { print }' \
+  "$fenced_title_fixture" > "$fenced_title_fixture.tmp"
+mv "$fenced_title_fixture.tmp" "$fenced_title_fixture"
+cat >> "$fenced_title_fixture" <<'EOF'
+
+```markdown
+# fixture-skill — Validate Markdown Headings
+```
+EOF
+expect_failure fenced-title "$fenced_title_fixture" 'title must use'
+
+fenced_language_rules_fixture="$(new_fixture fenced-language-rules)"
+awk '$0 == "## Language Rules" { print "Language Rules"; next } { print }' \
+  "$fenced_language_rules_fixture" > "$fenced_language_rules_fixture.tmp"
+mv "$fenced_language_rules_fixture.tmp" "$fenced_language_rules_fixture"
+cat >> "$fenced_language_rules_fixture" <<'EOF'
+
+```markdown
+## Language Rules
+```
+EOF
+expect_failure fenced-language-rules "$fenced_language_rules_fixture" 'missing Language Rules'
+
+unterminated_fixture="$(new_fixture unterminated-fence)"
+cat >> "$unterminated_fixture" <<'EOF'
+
+```text
+## 日本語の出力例
+EOF
+expect_failure unterminated-fence "$unterminated_fixture" 'unclosed fenced code block'
+
+unterminated_frontmatter_fixture="$(new_fixture unterminated-frontmatter)"
+awk '$0 == "---" { count++; if (count == 2) next } { print }' \
+  "$unterminated_frontmatter_fixture" > "$unterminated_frontmatter_fixture.tmp"
+mv "$unterminated_frontmatter_fixture.tmp" "$unterminated_frontmatter_fixture"
+expect_failure unterminated-frontmatter "$unterminated_frontmatter_fixture" 'unclosed YAML frontmatter'
+
+printf 'SKILL_QUALITY_CONTRACT_SUMMARY\tPASS\n'

--- a/skills/agent-delegate/references/scripts/tests/run_tests.sh
+++ b/skills/agent-delegate/references/scripts/tests/run_tests.sh
@@ -5,6 +5,7 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$(cd "$TEST_DIR/.." && pwd)/agent-delegate.sh"
 HARNESS="$TEST_DIR/heartbeat_harness.sh"
 QUALITY="$TEST_DIR/check_skill_quality.sh"
+QUALITY_CONTRACT="$TEST_DIR/check_skill_quality_contract.sh"
 STUB_DIR="$TEST_DIR/stubs"
 FIXTURE_DIR="$TEST_DIR/fixtures"
 REPO_ROOT="$(git -C "$TEST_DIR" rev-parse --show-toplevel)"
@@ -58,12 +59,12 @@ dry_validate_case() {
   case "$kind" in suite|meta) : ;; *) die "$case_name has invalid kind: $kind" ;; esac
   [ -n "$expected" ] || die "$case_name has no expected artifact"
   [ -f "$FIXTURE_DIR/$fixture" ] || die "$case_name fixture does not exist: $fixture"
-  /bin/bash -n "$SCRIPT" "$HARNESS" "$QUALITY" "$TEST_DIR/run_tests.sh" "$STUB_DIR/codex" "$STUB_DIR/claude"
+  /bin/bash -n "$SCRIPT" "$HARNESS" "$QUALITY" "$QUALITY_CONTRACT" "$TEST_DIR/run_tests.sh" "$STUB_DIR/codex" "$STUB_DIR/claude"
   if grep -En '(^|[[:space:]])sleep([[:space:]]|$)|https?://|(^|[[:space:]])(curl|wget)([[:space:]]|$)' \
-      "$HARNESS" "$STUB_DIR/codex" "$STUB_DIR/claude" >/dev/null; then
+      "$HARNESS" "$QUALITY_CONTRACT" "$STUB_DIR/codex" "$STUB_DIR/claude" >/dev/null; then
     die "$case_name depends on sleep, network, or a real peer"
   fi
-  [ -x "$HARNESS" ] && [ -x "$QUALITY" ] && [ -x "$STUB_DIR/codex" ] && [ -x "$STUB_DIR/claude" ] ||
+  [ -x "$HARNESS" ] && [ -x "$QUALITY" ] && [ -x "$QUALITY_CONTRACT" ] && [ -x "$STUB_DIR/codex" ] && [ -x "$STUB_DIR/claude" ] ||
     die "$case_name requires executable harness/checker/stubs"
   printf 'DRY_RUN_OK\t%s\t%s\t%s\n' "$case_name" "$fixture" "$expected"
 }
@@ -1970,12 +1971,14 @@ case_monitor_only_publishers() {
 }
 
 case_allowed_scope_and_skill_style() {
-  local changed bad_dir
+  local changed bad_dir skill_files
   changed="$(git -C "$REPO_ROOT" status --porcelain | sed 's/^...//' | sed 's/^"//;s/"$//' || true)"
   while IFS= read -r path; do
     [ -z "$path" ] && continue
     case "$path" in
-      README.md|README.ja.md|skills/agent-delegate/SKILL.md|skills/agent-delegate/references/contract.md|skills/agent-delegate/references/contract.ja.md) : ;;
+      AGENTS.md|README.md|README.ja.md|docs/coding-rules.md|docs/review_rules.md|docs/skill-style-guide.md) : ;;
+      skills/agent-delegate/SKILL.md|skills/agent-delegate/references/contract.md|skills/agent-delegate/references/contract.ja.md) : ;;
+      skills/mcp-convert/SKILL.md) : ;;
       skills/agent-delegate/references/scripts/agent-delegate.sh|skills/agent-delegate/references/scripts/tests/*) : ;;
       skills/spec-orchestrate/SKILL.md|skills/spec-orchestrate/references/role-dispatch.md|skills/spec-orchestrate/references/role-dispatch.ja.md) : ;;
       skills/spec-orchestrate/references/phases/spec_generate.md|skills/spec-orchestrate/references/phases/spec_generate.ja.md) : ;;
@@ -1988,7 +1991,10 @@ case_allowed_scope_and_skill_style() {
   done <<EOF
 $changed
 EOF
-  bash "$QUALITY" "$REPO_ROOT/skills/agent-delegate/SKILL.md" "$REPO_ROOT/skills/spec-orchestrate/SKILL.md" "$REPO_ROOT/skills/spec-implement/SKILL.md" "$REPO_ROOT/skills/spec-evaluate/SKILL.md" >/dev/null
+  bash "$QUALITY_CONTRACT" >/dev/null
+  skill_files=("$REPO_ROOT"/skills/*/SKILL.md)
+  [ -f "${skill_files[0]}" ] || die 'quality checker found no SKILL.md files'
+  bash "$QUALITY" "${skill_files[@]}" >/dev/null
   bad_dir="$(new_work_dir)/wrong-name"; mkdir -p "$bad_dir"; cp "$REPO_ROOT/skills/agent-delegate/SKILL.md" "$bad_dir/SKILL.md"
   if bash "$QUALITY" "$bad_dir/SKILL.md" >/dev/null 2>&1; then rm -rf "$(dirname "$bad_dir")"; die "quality checker accepted a broken directory/name relation"; fi
   rm -rf "$(dirname "$bad_dir")"

--- a/skills/mcp-convert/SKILL.md
+++ b/skills/mcp-convert/SKILL.md
@@ -26,7 +26,7 @@ description: |
 license: MIT
 ---
 
-# mcp-convert
+# mcp-convert — Convert MCP Configuration
 
 Convert Claude Code MCP settings into Codex CLI MCP configuration.
 


### PR DESCRIPTION
## 概要

SKILL.md品質検査の見出し判定を、Markdownのfenced code blockを考慮する実装へ変更します。

Closes #153

## 背景

従来の検査はファイル全体を正規表現で検索していたため、コードフェンス内にある日本語の出力例も文書見出しとして誤検出していました。
一方で、`mcp-convert` の実際のH1タイトル違反は修正が必要でした。

## 変更内容

- backtick／tildeフェンス、0〜3スペースのインデント、長い終了フェンスを解釈する見出し抽出を追加
- YAML frontmatterとfenced code block内のATX見出しを検査対象外に変更
- 未終端のfrontmatter／コードフェンスを個別のエラーとして検出
- タイトル、`Language Rules`、英語見出しの判定を同じ抽出結果へ統一
- `mcp-convert` のH1を規約準拠の英語タイトルへ修正
- 独立fixtureによる回帰・mutationテストを追加
- 全SKILL.mdの品質検査を既存テストランナーへ組み込み
- スタイルガイド、コーディング規約、レビュー規約、AGENTS.mdを実装に合わせて更新

## 検証

- `bash skills/agent-delegate/references/scripts/tests/check_skill_quality_contract.sh`
- `bash skills/agent-delegate/references/scripts/tests/check_skill_quality.sh skills/*/SKILL.md`（23件PASS）
- `python3 .../quick_validate.py`（全23スキルPASS）
- `bash scripts/check-skill-line-budget.sh`
- `bash scripts/tests/check-skill-reference-split-contract.sh`
- `bash skills/agent-delegate/references/scripts/tests/run_tests.sh --case allowed-scope-and-skill-style`
- `git diff --check`
- Claude read-onlyレビュー: Gate PASS

## 既知のベースライン失敗

- `run_tests.sh --all` は、mainに存在しない `.specs/agent-delegate-heartbeat/requirement.md` を要求する既存ケースで停止
- `check-skill-line-budget-contract.sh` は、現在23スキルに対して期待値を22に固定しているため失敗

いずれも今回の差分ではスキル追加や `.specs/` の変更を行っておらず、main由来の既存不整合です。
