### PR TITLE
fix(spec-orchestrate): run_id のない legacy ledger 行を正規化する

### DIFF
--- a/skills/spec-orchestrate/references/pipeline-config.ja.md
+++ b/skills/spec-orchestrate/references/pipeline-config.ja.md
@@ -368,9 +368,12 @@ recordへ書く。
 
 legacy ledgerで最初にactive recordを比較する前に、`retrospective-ledger.sh list-metrics`で
 `run_id`ごとの重複したversionなしrowを探す。物理的に最新のrowを残し、古い各duplicateへ
-`legacy_migration` supersede eventを追記する。安定したevent idは
-`supersede:<legacy-id>:legacy_migration`。履歴を書き換えず、1回のmigrationでselectorを
-一意にする。
+`legacy_migration` supersede eventを追記する。event idはhelperの出力から作る
+`supersede:<legacy-id>:legacy_migration`とする。`record_id`または`run_id`がないrowを読むと、
+helperはそれぞれ`legacy:<物理行>`と`legacy-run:<featureまたはunknown>:<物理行>`を補う。
+どちらの合成IDも1始まりの物理行位置に依存するため、JSON Linesの先頭へrowを挿入すると
+値が変わる。`list-metrics`が返した正規化後のIDを取得し、legacy rowより前へrowを挿入せずに
+migration eventを追記する。履歴を書き換えず、1回のmigrationでselectorを一意にする。
 
 resume対象のlegacy完了runでは、対応する最新metrics rowからstateの`run_id`をbackfillする。
 最後のlegacy rowも`legacy_migration`でsupersedeし、現在のstate、report、rowからversion付き

--- a/skills/spec-orchestrate/references/pipeline-config.md
+++ b/skills/spec-orchestrate/references/pipeline-config.md
@@ -387,9 +387,15 @@ pr, apply this order without an integrity-check gap:
 Before the first active-record comparison on a legacy ledger, use
 `retrospective-ledger.sh list-metrics` to find duplicate unversioned rows per
 `run_id`. Preserve the physically newest row and append `legacy_migration`
-supersede events for every older duplicate, using stable event ids
-`supersede:<legacy-id>:legacy_migration`. This one-time migration makes selection
-unambiguous without rewriting history.
+supersede events for every older duplicate, using event ids
+`supersede:<legacy-id>:legacy_migration` derived from the helper output. The
+helper normalizes missing `record_id` and `run_id` values as
+`legacy:<physical-row>` and
+`legacy-run:<feature-or-unknown>:<physical-row>`, respectively. The one-based
+physical row number makes both synthetic ids position-dependent, so prepending
+a JSON Lines entry changes them. Capture the normalized ids from `list-metrics`
+and append the migration events without inserting lines before the legacy rows.
+This one-time migration makes selection unambiguous without rewriting history.
 
 For the legacy completed run being resumed, backfill the state's `run_id` from
 its matching newest metrics row. Supersede that final legacy row with

--- a/skills/spec-orchestrate/references/scripts/retrospective-ledger.sh
+++ b/skills/spec-orchestrate/references/scripts/retrospective-ledger.sh
@@ -8,6 +8,7 @@
 #   retrospective-ledger.sh active-count <metrics.jsonl> <run-id>
 #   retrospective-ledger.sh list-active <metrics.jsonl>
 #   retrospective-ledger.sh list-metrics <metrics.jsonl> [run-id]
+# Synthetic legacy record_id and run_id values depend on physical line position; prepending lines changes them.
 
 set -euo pipefail
 
@@ -40,7 +41,8 @@ normalized_records() {
         | if ((.record_type // "metrics") == "metrics") then
             . + {
               record_type: "metrics",
-              record_id: (.record_id // ("legacy:" + (($index + 1) | tostring)))
+              record_id: (.record_id // ("legacy:" + (($index + 1) | tostring))),
+              run_id: (.run_id // ("legacy-run:" + (.feature // "unknown") + ":" + (($index + 1) | tostring)))
             }
           else . end
       )

--- a/skills/spec-orchestrate/references/scripts/tests/check-retrospective-resume-contract.sh
+++ b/skills/spec-orchestrate/references/scripts/tests/check-retrospective-resume-contract.sh
@@ -200,6 +200,33 @@ for file in "$IMPROVE_APPLY" "$IMPROVE_APPLY_JA"; do
 done
 printf 'PASS\tcontract\tretrospective resume bilingual fixture and mutations\n'
 
+runless_legacy_metrics="$tmp/runless-legacy-metrics.jsonl"
+printf '%s\n' \
+  '{"feature":"legacy-alpha","rounds_spec":1}' \
+  '{"feature":"legacy-beta","rounds_spec":2}' \
+  > "$runless_legacy_metrics"
+runless_active="$(bash "$LEDGER" list-active "$runless_legacy_metrics")" ||
+  fail "active selector rejected legacy rows without run ids"
+[ "$(printf '%s\n' "$runless_active" | jq -s 'length')" -eq 2 ] ||
+  fail "active selector did not return both legacy rows without run ids"
+[ "$(printf '%s\n' "$runless_active" | jq -sc '[.[].run_id]')" = \
+    '["legacy-run:legacy-alpha:1","legacy-run:legacy-beta:2"]' ] ||
+  fail "legacy rows without run ids were not assigned the expected unique synthetic values"
+runless_oldest_id="$(printf '%s\n' "$runless_active" | head -1 | jq -r .record_id)"
+runless_oldest_run="$(printf '%s\n' "$runless_active" | head -1 | jq -r .run_id)"
+runless_event="$(jq -nc --arg id "supersede:$runless_oldest_id:legacy_migration" \
+  --arg run "$runless_oldest_run" --arg target "$runless_oldest_id" \
+  '{record_type:"supersede",event_id:$id,run_id:$run,
+    supersedes:$target,reason:"legacy_migration"}')"
+bash "$LEDGER" supersede-once "$runless_legacy_metrics" "$runless_event" >/dev/null ||
+  fail "synthetic legacy run id could not be used for migration"
+[ "$(bash "$LEDGER" active-count "$runless_legacy_metrics" "$runless_oldest_run")" -eq 0 ] ||
+  fail "legacy row remained active after migration by synthetic run id"
+[ "$(bash "$LEDGER" active-count "$runless_legacy_metrics" \
+    "legacy-run:legacy-beta:2")" -eq 1 ] ||
+  fail "unrelated synthetic legacy run did not remain active after migration"
+printf 'PASS\tmigration\tlegacy metrics without run ids normalized and superseded\n'
+
 legacy_metrics="$tmp/legacy-metrics.jsonl"
 printf '%s\n' \
   '{"feature":"legacy","run_id":"legacy-run","rounds_spec":1}' \


### PR DESCRIPTION
## 概要

`run_id` がない legacy metrics 行を読み込んだときに、retrospective ledger 全体の `list-active` が失敗する問題を修正します。

## 原因

legacy 行の正規化では `record_id` だけを補完し、`run_id` は `null` のまま残していました。

そのため、`list-active` の有効性検査に失敗し、helper を使った migration でも対象行を指定できませんでした。

## 変更内容

- 欠落した `run_id` を feature と物理行位置から合成します。
- 合成した `record_id` と `run_id` が物理行位置に依存することを英日文書へ追記します。
- `run_id` がない2行の列挙、合成IDの一意性、`legacy_migration`、未移行行の維持を回帰テストで固定します。

## 影響

既存の JSON Lines を書き換えずに、`run_id` がない legacy 行を `list-active` と `supersede-once` で扱えるようになります。

## 動作確認

- [x] `bash skills/spec-orchestrate/references/scripts/tests/check-retrospective-resume-contract.sh`
- [x] `bash skills/spec-orchestrate/references/scripts/tests/run_tests.sh`
- [x] `bash scripts/check-skill-line-budget.sh`
- [x] `bash skills/agent-delegate/references/scripts/tests/check_skill_quality.sh skills/*/SKILL.md`
- [x] `bash scripts/tests/check-skill-reference-split-contract.sh`
- [x] Claude の読み取り専用レビュー（Gate: PASS、再レビュー findings 0）

Closes #157
